### PR TITLE
fix: Remove duplicate checkout step in deploy job

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -105,7 +105,6 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-      - uses: actions/checkout@v4
       - uses: google-github-actions/setup-gcloud@v2
         with:
           install_components: kubectl,gke-gcloud-auth-plugin


### PR DESCRIPTION
## Summary
- Remove duplicate `actions/checkout` in deploy job that was wiping auth credentials
- Caused by squash merges of PRs #7 and #8 both including a checkout step

## Test plan
- [ ] Deploy job succeeds after merge

Generated with [Claude Code](https://claude.com/claude-code)