### PR TITLE
fix: Use gatewayEditor role for deploy service account

### DIFF
--- a/infrastructure/terraform/modules/workload-identity-federation/variables.tf
+++ b/infrastructure/terraform/modules/workload-identity-federation/variables.tf
@@ -55,7 +55,7 @@ variable "service_account_roles" {
   default = [
     "roles/artifactregistry.writer",
     "roles/container.developer",
-    "roles/gkehub.gatewayReader",
+    "roles/gkehub.gatewayEditor",
     "roles/gkehub.viewer"
   ]
 }


### PR DESCRIPTION
## Summary
- Change Connect Gateway role from `gatewayReader` to `gatewayEditor` for the GitHub Actions service account
- `gatewayReader` only allows read operations (get, list) through Connect Gateway — creating Deployments and Services requires write access

## Context
Deploy job fails with `Error from server (Forbidden): error when creating ".": unknown (post deployments.apps)`. The SA has `container.developer` (GKE-level permission) but Connect Gateway enforces its own RBAC layer, and `gatewayReader` blocks writes.

## After merge
Run `terraform apply` in `infrastructure/terraform/environments/prod/` to update the IAM binding, then re-run the failed deploy workflow.

## Test plan
- [ ] `terraform plan` shows only the role change
- [ ] After apply, deploy job succeeds

Generated with [Claude Code](https://claude.com/claude-code)