### PR TITLE
perf: Skip setup-gcloud in deploy, use pre-installed gcloud

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -105,9 +105,7 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
-        with:
-          install_components: kubectl,gke-gcloud-auth-plugin
+      - run: gcloud components install gke-gcloud-auth-plugin --quiet
       - name: Get GKE credentials via Connect Gateway
         run: |
           gcloud container fleet memberships get-credentials ${{ secrets.GKE_CLUSTER }} \


### PR DESCRIPTION
## Summary
- Replace `setup-gcloud` action (~56s) with a single `gcloud components install gke-gcloud-auth-plugin`
- ubuntu-latest already has gcloud and kubectl pre-installed

## Test plan
- [ ] Deploy job succeeds
- [ ] Deploy step is faster

Generated with [Claude Code](https://claude.com/claude-code)