### PR TITLE
fix: Use apt-get to install gke-gcloud-auth-plugin on GitHub Actions

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -105,7 +105,7 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-      - run: gcloud components install gke-gcloud-auth-plugin --quiet
+      - run: sudo apt-get install -y google-cloud-cli-gke-gcloud-auth-plugin
       - name: Get GKE credentials via Connect Gateway
         run: |
           gcloud container fleet memberships get-credentials ${{ secrets.GKE_CLUSTER }} \


### PR DESCRIPTION
## Summary
- Deploy job fails because `gcloud components install` is disabled on GitHub Actions runners (apt-managed gcloud)
- Replaced with `sudo apt-get install -y google-cloud-cli-gke-gcloud-auth-plugin`

## Test plan
- [ ] Merge PR and verify deploy job passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)