### PR TITLE
fix: Use setup-gcloud action to install gke-gcloud-auth-plugin

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -105,7 +105,9 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-      - run: sudo apt-get install -y google-cloud-cli-gke-gcloud-auth-plugin
+      - uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: gke-gcloud-auth-plugin
       - name: Get GKE credentials via Connect Gateway
         run: |
           gcloud container fleet memberships get-credentials ${{ secrets.GKE_CLUSTER }} \


### PR DESCRIPTION
## Summary
- Previous fix (`apt-get install`) failed because the Google Cloud apt source isn't configured on the runner
- Use `google-github-actions/setup-gcloud@v2` with `install_components: gke-gcloud-auth-plugin` — the official supported way to install gcloud components on GitHub Actions

## Test plan
- [ ] Merge and verify deploy job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)