### PR TITLE
fix: address P2 bugs — idempotent events, status validation, argIdx, revision auth

### DIFF
--- a/go-backend/internal/handler/revisions.go
+++ b/go-backend/internal/handler/revisions.go
@@ -23,6 +23,12 @@ func NewRevisionHandler(revisions store.RevisionRepository) *RevisionHandler {
 
 // List handles GET /api/v1/sessions/{sessionID}/revisions — returns revisions for a session.
 func (h *RevisionHandler) List(w http.ResponseWriter, r *http.Request) {
+	authUser := auth.UserFromContext(r.Context())
+	if authUser == nil {
+		httputil.WriteError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
 	sessionID, ok := httputil.ParseUUIDParam(w, r, "sessionID")
 	if !ok {
 		return

--- a/go-backend/internal/handler/revisions_test.go
+++ b/go-backend/internal/handler/revisions_test.go
@@ -335,3 +335,19 @@ func TestCreateRevision_InternalError(t *testing.T) {
 		t.Fatalf("expected 500, got %d", rec.Code)
 	}
 }
+
+func TestListRevisions_Unauthorized(t *testing.T) {
+	h := NewRevisionHandler(&mockRevisionRepo{})
+	sessionID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := revisionRouteCtx(sessionID.String())
+	// No auth user in context
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.List(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}

--- a/go-backend/internal/handler/sessions.go
+++ b/go-backend/internal/handler/sessions.go
@@ -61,6 +61,10 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if status := r.URL.Query().Get("status"); status != "" {
+		if status != "active" && status != "completed" {
+			httputil.WriteError(w, http.StatusBadRequest, "invalid status: must be 'active' or 'completed'")
+			return
+		}
 		filters.Status = &status
 	}
 
@@ -151,6 +155,17 @@ func (h *SessionHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return // BindJSON already wrote the error response
 	}
 
+	// Fetch current state to detect actual changes for event publishing.
+	previous, err := h.sessions.GetSession(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
 	params := store.UpdateSessionParams{
 		FeaturedStudentID: req.FeaturedStudentID,
 		FeaturedCode:      req.FeaturedCode,
@@ -173,16 +188,19 @@ func (h *SessionHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Publish real-time events asynchronously after successful update.
-	if req.Status != nil && *req.Status == "completed" {
+	// Publish real-time events only when the value actually changed.
+	if req.Status != nil && *req.Status == "completed" && previous.Status != "completed" {
 		publishAsync(r, h.logger, id, func(ctx context.Context) error {
 			return h.publisher.SessionEnded(ctx, id.String(), "completed")
 		})
 	}
 	if req.FeaturedStudentID != nil && req.FeaturedCode != nil {
-		publishAsync(r, h.logger, id, func(ctx context.Context) error {
-			return h.publisher.FeaturedStudentChanged(ctx, id.String(), req.FeaturedStudentID.String(), *req.FeaturedCode)
-		})
+		featuredChanged := previous.FeaturedStudentID == nil || *previous.FeaturedStudentID != *req.FeaturedStudentID
+		if featuredChanged {
+			publishAsync(r, h.logger, id, func(ctx context.Context) error {
+				return h.publisher.FeaturedStudentChanged(ctx, id.String(), req.FeaturedStudentID.String(), *req.FeaturedCode)
+			})
+		}
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, session)

--- a/go-backend/internal/handler/sessions_test.go
+++ b/go-backend/internal/handler/sessions_test.go
@@ -370,9 +370,13 @@ func TestCreateSession_InternalError(t *testing.T) {
 func TestUpdateSession_Success(t *testing.T) {
 	sess := testSession()
 	featuredID := uuid.New()
-	sess.FeaturedStudentID = &featuredID
+	updatedSess := *sess
+	updatedSess.FeaturedStudentID = &featuredID
 
 	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return sess, nil
+		},
 		updateSessionFn: func(_ context.Context, id uuid.UUID, params store.UpdateSessionParams) (*store.Session, error) {
 			if id != sess.ID {
 				t.Fatalf("unexpected id: %v", id)
@@ -380,7 +384,7 @@ func TestUpdateSession_Success(t *testing.T) {
 			if params.FeaturedStudentID == nil || *params.FeaturedStudentID != featuredID {
 				t.Fatalf("unexpected featured_student_id: %v", params.FeaturedStudentID)
 			}
-			return sess, nil
+			return &updatedSess, nil
 		},
 	}
 
@@ -413,14 +417,18 @@ func TestUpdateSession_Success(t *testing.T) {
 }
 
 func TestUpdateSession_EndSession(t *testing.T) {
-	sess := testSession()
+	prevSess := testSession() // status "active"
 	now := time.Now()
-	sess.Status = "completed"
-	sess.EndedAt = &now
+	completedSess := *prevSess
+	completedSess.Status = "completed"
+	completedSess.EndedAt = &now
 
 	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return prevSess, nil
+		},
 		updateSessionFn: func(_ context.Context, id uuid.UUID, params store.UpdateSessionParams) (*store.Session, error) {
-			if id != sess.ID {
+			if id != prevSess.ID {
 				t.Fatalf("unexpected id: %v", id)
 			}
 			if params.Status == nil || *params.Status != "completed" {
@@ -429,7 +437,7 @@ func TestUpdateSession_EndSession(t *testing.T) {
 			if params.EndedAt == nil {
 				t.Fatalf("expected ended_at to be set when status is completed")
 			}
-			return sess, nil
+			return &completedSess, nil
 		},
 	}
 
@@ -437,10 +445,10 @@ func TestUpdateSession_EndSession(t *testing.T) {
 		"status": "completed",
 	})
 	h := NewSessionHandler(repo, noopPublisher(), testLogger())
-	req := httptest.NewRequest(http.MethodPatch, "/"+sess.ID.String(), bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/"+prevSess.ID.String(), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("id", sess.ID.String())
+	rctx.URLParams.Add("id", prevSess.ID.String())
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 	ctx = auth.WithUser(ctx, &auth.User{ID: uuid.New(), Role: auth.RoleInstructor})
 	req = req.WithContext(ctx)
@@ -455,7 +463,7 @@ func TestUpdateSession_EndSession(t *testing.T) {
 
 func TestUpdateSession_NotFound(t *testing.T) {
 	repo := &mockSessionRepo{
-		updateSessionFn: func(_ context.Context, _ uuid.UUID, _ store.UpdateSessionParams) (*store.Session, error) {
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
 			return nil, store.ErrNotFound
 		},
 	}
@@ -578,13 +586,17 @@ func TestUpdateSession_InvalidBody(t *testing.T) {
 }
 
 func TestUpdateSession_InternalError(t *testing.T) {
+	sess := testSession()
 	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return sess, nil
+		},
 		updateSessionFn: func(_ context.Context, _ uuid.UUID, _ store.UpdateSessionParams) (*store.Session, error) {
 			return nil, errors.New("db error")
 		},
 	}
 
-	id := uuid.New()
+	id := sess.ID
 	body, _ := json.Marshal(map[string]any{"status": "completed"})
 	h := NewSessionHandler(repo, noopPublisher(), testLogger())
 	req := httptest.NewRequest(http.MethodPatch, "/"+id.String(), bytes.NewReader(body))
@@ -653,24 +665,28 @@ func TestUpdateSession_RBACForbidden(t *testing.T) {
 // --- Publisher integration tests ---
 
 func TestUpdateSession_EndSession_PublishesSessionEnded(t *testing.T) {
-	sess := testSession()
+	prevSess := testSession() // status "active"
 	now := time.Now()
-	sess.Status = "completed"
-	sess.EndedAt = &now
+	completedSess := *prevSess
+	completedSess.Status = "completed"
+	completedSess.EndedAt = &now
 
 	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return prevSess, nil
+		},
 		updateSessionFn: func(_ context.Context, _ uuid.UUID, _ store.UpdateSessionParams) (*store.Session, error) {
-			return sess, nil
+			return &completedSess, nil
 		},
 	}
 	pub := newMockPublisher()
 	h := NewSessionHandler(repo, pub, testLogger())
 
 	body, _ := json.Marshal(map[string]any{"status": "completed"})
-	req := httptest.NewRequest(http.MethodPatch, "/"+sess.ID.String(), bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/"+prevSess.ID.String(), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("id", sess.ID.String())
+	rctx.URLParams.Add("id", prevSess.ID.String())
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 	ctx = auth.WithUser(ctx, &auth.User{ID: uuid.New(), Role: auth.RoleInstructor})
 	req = req.WithContext(ctx)
@@ -687,8 +703,8 @@ func TestUpdateSession_EndSession_PublishesSessionEnded(t *testing.T) {
 	if len(pub.sessionEndedCalls) != 1 {
 		t.Fatalf("expected 1 SessionEnded call, got %d", len(pub.sessionEndedCalls))
 	}
-	if pub.sessionEndedCalls[0].sessionID != sess.ID.String() {
-		t.Errorf("expected session_id %q, got %q", sess.ID, pub.sessionEndedCalls[0].sessionID)
+	if pub.sessionEndedCalls[0].sessionID != prevSess.ID.String() {
+		t.Errorf("expected session_id %q, got %q", prevSess.ID, pub.sessionEndedCalls[0].sessionID)
 	}
 	if pub.sessionEndedCalls[0].reason != "completed" {
 		t.Errorf("expected reason %q, got %q", "completed", pub.sessionEndedCalls[0].reason)
@@ -696,15 +712,19 @@ func TestUpdateSession_EndSession_PublishesSessionEnded(t *testing.T) {
 }
 
 func TestUpdateSession_FeaturedStudent_PublishesFeaturedStudentChanged(t *testing.T) {
-	sess := testSession()
+	prevSess := testSession() // no featured student
 	featuredID := uuid.New()
-	sess.FeaturedStudentID = &featuredID
 	featuredCode := "print('featured')"
-	sess.FeaturedCode = &featuredCode
+	updatedSess := *prevSess
+	updatedSess.FeaturedStudentID = &featuredID
+	updatedSess.FeaturedCode = &featuredCode
 
 	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return prevSess, nil
+		},
 		updateSessionFn: func(_ context.Context, _ uuid.UUID, _ store.UpdateSessionParams) (*store.Session, error) {
-			return sess, nil
+			return &updatedSess, nil
 		},
 	}
 	pub := newMockPublisher()
@@ -714,10 +734,10 @@ func TestUpdateSession_FeaturedStudent_PublishesFeaturedStudentChanged(t *testin
 		"featured_student_id": featuredID.String(),
 		"featured_code":       featuredCode,
 	})
-	req := httptest.NewRequest(http.MethodPatch, "/"+sess.ID.String(), bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/"+prevSess.ID.String(), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("id", sess.ID.String())
+	rctx.URLParams.Add("id", prevSess.ID.String())
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 	ctx = auth.WithUser(ctx, &auth.User{ID: uuid.New(), Role: auth.RoleInstructor})
 	req = req.WithContext(ctx)
@@ -735,8 +755,8 @@ func TestUpdateSession_FeaturedStudent_PublishesFeaturedStudentChanged(t *testin
 		t.Fatalf("expected 1 FeaturedStudentChanged call, got %d", len(pub.featuredStudentChangedCalls))
 	}
 	call := pub.featuredStudentChangedCalls[0]
-	if call.sessionID != sess.ID.String() {
-		t.Errorf("expected session_id %q, got %q", sess.ID, call.sessionID)
+	if call.sessionID != prevSess.ID.String() {
+		t.Errorf("expected session_id %q, got %q", prevSess.ID, call.sessionID)
 	}
 	if call.userID != featuredID.String() {
 		t.Errorf("expected user_id %q, got %q", featuredID, call.userID)
@@ -747,24 +767,28 @@ func TestUpdateSession_FeaturedStudent_PublishesFeaturedStudentChanged(t *testin
 }
 
 func TestUpdateSession_EndSession_SucceedsWhenPublisherFails(t *testing.T) {
-	sess := testSession()
+	prevSess := testSession() // status "active"
 	now := time.Now()
-	sess.Status = "completed"
-	sess.EndedAt = &now
+	completedSess := *prevSess
+	completedSess.Status = "completed"
+	completedSess.EndedAt = &now
 
 	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return prevSess, nil
+		},
 		updateSessionFn: func(_ context.Context, _ uuid.UUID, _ store.UpdateSessionParams) (*store.Session, error) {
-			return sess, nil
+			return &completedSess, nil
 		},
 	}
 	pub := newMockPublisherWithErr(errors.New("publish failed"))
 	h := NewSessionHandler(repo, pub, testLogger())
 
 	body, _ := json.Marshal(map[string]any{"status": "completed"})
-	req := httptest.NewRequest(http.MethodPatch, "/"+sess.ID.String(), bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPatch, "/"+prevSess.ID.String(), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("id", sess.ID.String())
+	rctx.URLParams.Add("id", prevSess.ID.String())
 	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
 	ctx = auth.WithUser(ctx, &auth.User{ID: uuid.New(), Role: auth.RoleInstructor})
 	req = req.WithContext(ctx)
@@ -778,7 +802,11 @@ func TestUpdateSession_EndSession_SucceedsWhenPublisherFails(t *testing.T) {
 }
 
 func TestUpdateSession_DBError_NoPublish(t *testing.T) {
+	sess := testSession()
 	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return sess, nil
+		},
 		updateSessionFn: func(_ context.Context, _ uuid.UUID, _ store.UpdateSessionParams) (*store.Session, error) {
 			return nil, errors.New("db error")
 		},
@@ -786,7 +814,7 @@ func TestUpdateSession_DBError_NoPublish(t *testing.T) {
 	pub := newMockPublisher()
 	h := NewSessionHandler(repo, pub, testLogger())
 
-	id := uuid.New()
+	id := sess.ID
 	body, _ := json.Marshal(map[string]any{"status": "completed"})
 	req := httptest.NewRequest(http.MethodPatch, "/"+id.String(), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -809,5 +837,108 @@ func TestUpdateSession_DBError_NoPublish(t *testing.T) {
 	defer pub.mu.Unlock()
 	if len(pub.sessionEndedCalls) != 0 {
 		t.Errorf("expected no SessionEnded calls when DB fails, got %d", len(pub.sessionEndedCalls))
+	}
+}
+
+func TestListSessions_InvalidStatus(t *testing.T) {
+	repo := &mockSessionRepo{}
+	h := NewSessionHandler(repo, noopPublisher(), testLogger())
+	req := httptest.NewRequest(http.MethodGet, "/?status=invalid", nil)
+	ctx := auth.WithUser(req.Context(), &auth.User{ID: uuid.New(), Role: auth.RoleStudent})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.List(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateSession_IdempotentEnd_NoPublish(t *testing.T) {
+	// Session is already completed; re-sending status=completed should not publish.
+	prevSess := testSession()
+	prevSess.Status = "completed"
+	now := time.Now()
+	prevSess.EndedAt = &now
+
+	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return prevSess, nil
+		},
+		updateSessionFn: func(_ context.Context, _ uuid.UUID, _ store.UpdateSessionParams) (*store.Session, error) {
+			return prevSess, nil
+		},
+	}
+	pub := newMockPublisher()
+	h := NewSessionHandler(repo, pub, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"status": "completed"})
+	req := httptest.NewRequest(http.MethodPatch, "/"+prevSess.ID.String(), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", prevSess.ID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = auth.WithUser(ctx, &auth.User{ID: uuid.New(), Role: auth.RoleInstructor})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.Update(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Brief sleep to confirm no publish calls arrive.
+	time.Sleep(50 * time.Millisecond)
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.sessionEndedCalls) != 0 {
+		t.Errorf("expected no SessionEnded calls on idempotent end, got %d", len(pub.sessionEndedCalls))
+	}
+}
+
+func TestUpdateSession_IdempotentFeaturedStudent_NoPublish(t *testing.T) {
+	// Featured student is already set to the same ID; re-sending should not publish.
+	featuredID := uuid.New()
+	prevSess := testSession()
+	prevSess.FeaturedStudentID = &featuredID
+	code := "print('hello')"
+	prevSess.FeaturedCode = &code
+
+	repo := &mockSessionRepo{
+		getSessionFn: func(_ context.Context, _ uuid.UUID) (*store.Session, error) {
+			return prevSess, nil
+		},
+		updateSessionFn: func(_ context.Context, _ uuid.UUID, _ store.UpdateSessionParams) (*store.Session, error) {
+			return prevSess, nil
+		},
+	}
+	pub := newMockPublisher()
+	h := NewSessionHandler(repo, pub, testLogger())
+
+	body, _ := json.Marshal(map[string]any{
+		"featured_student_id": featuredID.String(),
+		"featured_code":       code,
+	})
+	req := httptest.NewRequest(http.MethodPatch, "/"+prevSess.ID.String(), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", prevSess.ID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = auth.WithUser(ctx, &auth.User{ID: uuid.New(), Role: auth.RoleInstructor})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.Update(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Brief sleep to confirm no publish calls arrive.
+	time.Sleep(50 * time.Millisecond)
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.featuredStudentChangedCalls) != 0 {
+		t.Errorf("expected no FeaturedStudentChanged calls on idempotent update, got %d", len(pub.featuredStudentChangedCalls))
 	}
 }

--- a/go-backend/internal/store/problems.go
+++ b/go-backend/internal/store/problems.go
@@ -173,6 +173,7 @@ func (s *Store) UpdateProblem(ctx context.Context, id uuid.UUID, params UpdatePr
 	if params.ClassID != nil {
 		query += fmt.Sprintf("\n		    class_id           = $%d,", argIdx)
 		args = append(args, *params.ClassID)
+		argIdx++ //nolint:ineffassign // keep argIdx consistent for future fields
 	}
 
 	query += `

--- a/go-backend/internal/store/sessions.go
+++ b/go-backend/internal/store/sessions.go
@@ -33,6 +33,7 @@ func (s *Store) ListSessions(ctx context.Context, filters SessionFilters) ([]Ses
 	if filters.Status != nil {
 		query += fmt.Sprintf(" AND status = $%d", argIdx)
 		args = append(args, *filters.Status)
+		argIdx++ //nolint:ineffassign // keep argIdx consistent for future filters
 	}
 	query += " ORDER BY created_at DESC"
 
@@ -184,6 +185,7 @@ func (s *Store) UpdateSession(ctx context.Context, id uuid.UUID, params UpdateSe
 	if params.EndedAt != nil {
 		query += fmt.Sprintf(",\n		    ended_at = $%d", argIdx)
 		args = append(args, *params.EndedAt)
+		argIdx++ //nolint:ineffassign // keep argIdx consistent for future fields
 	}
 
 	query += `


### PR DESCRIPTION
## Summary
- **PLAT-bu7**: Prevent duplicate realtime event emission on idempotent session updates by comparing against previous session state before publishing
- **PLAT-b1o**: Validate `status` query param on sessions List endpoint (must be `active` or `completed`)
- **PLAT-du6**: Add missing `argIdx++` on last conditional clauses in dynamic query builders to prevent future parameter index bugs
- **PLAT-mp5**: Add auth check to revision List handler; add unauthorized test

## Changes
- `handler/sessions.go`: Fetch session before update to detect actual state changes for event publishing; validate status query param
- `handler/revisions.go`: Add auth check to List handler
- `store/sessions.go`: Add `argIdx++` with nolint on last filter/field blocks
- `store/problems.go`: Add `argIdx++` with nolint on last field block
- `handler/sessions_test.go`: Update existing tests for new GetSession call; add idempotent event tests and invalid status test
- `handler/revisions_test.go`: Add unauthorized test for List

## Test plan
- [x] All existing tests pass with race detector
- [x] New tests: `TestListSessions_InvalidStatus`, `TestUpdateSession_IdempotentEnd_NoPublish`, `TestUpdateSession_IdempotentFeaturedStudent_NoPublish`, `TestListRevisions_Unauthorized`
- [x] Lint passes clean

Beads: PLAT-bu7, PLAT-b1o, PLAT-du6, PLAT-mp5

Generated with Claude Code