### PR TITLE
test: add store-layer integration tests for all CRUD operations

### DIFF
--- a/go-backend/internal/store/store_crud_integration_test.go
+++ b/go-backend/internal/store/store_crud_integration_test.go
@@ -519,7 +519,9 @@ func TestIntegration_DeleteClass(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		var count int
-		_ = conn.QueryRow(ctx, "SELECT COUNT(*) FROM classes WHERE id = $1", classID).Scan(&count)
+		if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM classes WHERE id = $1", classID).Scan(&count); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
 		if count != 0 {
 			t.Error("class should be deleted")
 		}
@@ -827,7 +829,9 @@ func TestIntegration_DeleteSection(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		var count int
-		_ = conn.QueryRow(ctx, "SELECT COUNT(*) FROM sections WHERE id = $1", sectionID).Scan(&count)
+		if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM sections WHERE id = $1", sectionID).Scan(&count); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
 		if count != 0 {
 			t.Error("section should be deleted")
 		}
@@ -1007,7 +1011,9 @@ func TestIntegration_DeleteMembership(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		var count int
-		_ = conn.QueryRow(ctx, "SELECT COUNT(*) FROM section_memberships WHERE section_id = $1 AND user_id = $2", sectionID, userID).Scan(&count)
+		if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM section_memberships WHERE section_id = $1 AND user_id = $2", sectionID, userID).Scan(&count); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
 		if count != 0 {
 			t.Error("membership should be deleted")
 		}

--- a/go-backend/internal/store/store_session_integration_test.go
+++ b/go-backend/internal/store/store_session_integration_test.go
@@ -328,7 +328,7 @@ func TestIntegration_UpdateSession(t *testing.T) {
 		if params.EndedAt != nil {
 			query += fmt.Sprintf(", ended_at = $%d", argIdx)
 			args = append(args, *params.EndedAt)
-			argIdx++
+			argIdx++ //nolint:ineffassign // keep argIdx consistent for future fields
 		}
 		if params.ClearEndedAt {
 			query += ", ended_at = NULL"
@@ -393,7 +393,7 @@ func TestIntegration_UpdateSession(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if sess.Status != "completed" {
-			t.Errorf("expected status 'ended', got %s", sess.Status)
+			t.Errorf("expected status 'completed', got %s", sess.Status)
 		}
 		if sess.EndedAt == nil {
 			t.Error("expected ended_at to be set")


### PR DESCRIPTION
## Summary
- Adds 36 new integration tests covering CRUD operations for all store entities: namespaces, classes, sections, memberships, sessions, session students, revisions, problems, and users
- Tests validate SQL query correctness and row scanning against a live PostgreSQL database
- Follows the existing `store_methods_integration_test.go` pattern (direct SQL execution against pool)

## Changes
- `store_crud_integration_test.go` — 16 tests for namespace/class/section/membership CRUD (create, get, list, update, delete, error paths)
- `store_session_integration_test.go` — 20 tests for session/session_student/revision/problem/user operations including dynamic updates, idempotent joins, and participant array management

## Test plan
- [x] All 49 integration tests pass (`DATABASE_URL=... go test -race -count=1 ./internal/store/... -run TestIntegration`)
- [x] All unit tests pass (`go test -race ./...`)
- [x] Correctness review passed (fixed error checks, error message, linter nolint)
- [x] Architecture review passed
- [x] Test quality review noted SQL duplication pattern — this matches existing convention; Store-method-level tests tracked separately

Beads: PLAT-1xo, PLAT-nil

Generated with Claude Code