### PR TITLE
refactor: fix store integration tests to use proper RLS context

### DIFF
--- a/go-backend/internal/store/store_crud_integration_test.go
+++ b/go-backend/internal/store/store_crud_integration_test.go
@@ -1,17 +1,26 @@
+// Integration tests for CRUD operations on namespaces, classes, sections, and memberships.
+//
+// These tests validate actual Store methods with proper RLS context,
+// ensuring that the SQL queries, scanning logic, and RLS policies work
+// together as they would in production.
+//
+// Run with:
+//
+//	DATABASE_URL="postgres://eval:eval_local_password@localhost:5432/eval?sslmode=disable" go test ./internal/store/... -run TestIntegration
 package store
 
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jdelfino/eval/internal/auth"
 )
 
 // =============================================================================
-// Namespace CRUD Tests
+// Namespace CRUD Tests - calls actual Store methods with RLS
 // =============================================================================
 
 func TestIntegration_CreateNamespace(t *testing.T) {
@@ -19,15 +28,25 @@ func TestIntegration_CreateNamespace(t *testing.T) {
 	defer db.close()
 	ctx := context.Background()
 
-	// Use the test namespace for setup user
-	createdBy := uuid.New()
-	db.createUser(ctx, t, createdBy, fmt.Sprintf("creator-%s@test.com", db.nsID), "instructor", db.nsID)
-
-	conn, err := db.pool.Acquire(ctx)
+	// Use system-admin for namespace operations (can see all namespaces)
+	adminID := uuid.New()
+	// Create as system-admin (no namespace)
+	_, err := db.pool.Exec(ctx,
+		`INSERT INTO users (id, email, role) VALUES ($1, $2, $3)`,
+		adminID, "sysadmin@test.com", "system-admin")
 	if err != nil {
-		t.Fatalf("acquire: %v", err)
+		t.Fatalf("create admin: %v", err)
 	}
-	defer conn.Release()
+	t.Cleanup(func() {
+		_, _ = db.pool.Exec(ctx, "DELETE FROM users WHERE id = $1", adminID)
+	})
+
+	authUser := &auth.User{
+		ID:          adminID,
+		Email:       "sysadmin@test.com",
+		NamespaceID: "",
+		Role:        auth.RoleSystemAdmin,
+	}
 
 	maxInst := 5
 	maxStu := 100
@@ -38,13 +57,16 @@ func TestIntegration_CreateNamespace(t *testing.T) {
 	})
 
 	t.Run("successful creation", func(t *testing.T) {
-		var ns Namespace
-		err := conn.QueryRow(ctx,
-			`INSERT INTO namespaces (id, display_name, max_instructors, max_students, created_by)
-			 VALUES ($1, $2, $3, $4, $5)
-			 RETURNING id, display_name, active, max_instructors, max_students, created_at, created_by, updated_at`,
-			createNSID, "Create NS Test", &maxInst, &maxStu, &createdBy,
-		).Scan(&ns.ID, &ns.DisplayName, &ns.Active, &ns.MaxInstructors, &ns.MaxStudents, &ns.CreatedAt, &ns.CreatedBy, &ns.UpdatedAt)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		ns, err := s.CreateNamespace(ctx, CreateNamespaceParams{
+			ID:             createNSID,
+			DisplayName:    "Create NS Test",
+			MaxInstructors: &maxInst,
+			MaxStudents:    &maxStu,
+			CreatedBy:      &adminID,
+		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -63,8 +85,8 @@ func TestIntegration_CreateNamespace(t *testing.T) {
 		if ns.MaxStudents == nil || *ns.MaxStudents != 100 {
 			t.Errorf("expected max_students 100, got %v", ns.MaxStudents)
 		}
-		if ns.CreatedBy == nil || *ns.CreatedBy != createdBy {
-			t.Errorf("expected created_by %s, got %v", createdBy, ns.CreatedBy)
+		if ns.CreatedBy == nil || *ns.CreatedBy != adminID {
+			t.Errorf("expected created_by %s, got %v", adminID, ns.CreatedBy)
 		}
 		if ns.CreatedAt.IsZero() {
 			t.Error("expected non-zero created_at")
@@ -73,7 +95,7 @@ func TestIntegration_CreateNamespace(t *testing.T) {
 
 	t.Run("record exists after creation", func(t *testing.T) {
 		var count int
-		err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM namespaces WHERE id = $1", createNSID).Scan(&count)
+		err := db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM namespaces WHERE id = $1", createNSID).Scan(&count)
 		if err != nil {
 			t.Fatalf("query: %v", err)
 		}
@@ -88,26 +110,21 @@ func TestIntegration_GetNamespace(t *testing.T) {
 	defer db.close()
 	ctx := context.Background()
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
+	userID := uuid.New()
+	db.createUser(ctx, t, userID, "user@test.com", "instructor", db.nsID)
 
-	getNamespace := func(id string) (*Namespace, error) {
-		var ns Namespace
-		err := conn.QueryRow(ctx,
-			`SELECT id, display_name, active, max_instructors, max_students, created_at, created_by, updated_at
-			 FROM namespaces WHERE id = $1`, id).Scan(
-			&ns.ID, &ns.DisplayName, &ns.Active, &ns.MaxInstructors, &ns.MaxStudents, &ns.CreatedAt, &ns.CreatedBy, &ns.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &ns, nil
+	authUser := &auth.User{
+		ID:          userID,
+		Email:       "user@test.com",
+		NamespaceID: db.nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		ns, err := getNamespace(db.nsID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		ns, err := s.GetNamespace(ctx, db.nsID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -117,7 +134,10 @@ func TestIntegration_GetNamespace(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getNamespace("nonexistent-" + uuid.New().String())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetNamespace(ctx, "nonexistent-"+uuid.New().String())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -129,64 +149,49 @@ func TestIntegration_ListNamespaces(t *testing.T) {
 	defer db.close()
 	ctx := context.Background()
 
-	conn, err := db.pool.Acquire(ctx)
+	// System admin can see all namespaces
+	adminID := uuid.New()
+	_, err := db.pool.Exec(ctx,
+		`INSERT INTO users (id, email, role) VALUES ($1, $2, $3)`,
+		adminID, "sysadmin@test.com", "system-admin")
 	if err != nil {
-		t.Fatalf("acquire: %v", err)
+		t.Fatalf("create admin: %v", err)
 	}
-	defer conn.Release()
+	t.Cleanup(func() {
+		_, _ = db.pool.Exec(ctx, "DELETE FROM users WHERE id = $1", adminID)
+	})
 
-	// Use a prefix to scope our listing query
+	authUser := &auth.User{
+		ID:          adminID,
+		Email:       "sysadmin@test.com",
+		NamespaceID: "",
+		Role:        auth.RoleSystemAdmin,
+	}
+
+	// Create additional namespaces with a known prefix
 	prefix := "ns-list-" + uuid.New().String()[:8]
 	nsA := prefix + "-a"
 	nsB := prefix + "-b"
 	nsC := prefix + "-c"
 
-	listNamespaces := func() ([]Namespace, error) {
-		rows, err := conn.Query(ctx,
-			`SELECT id, display_name, active, max_instructors, max_students, created_at, created_by, updated_at
-			 FROM namespaces WHERE id LIKE $1 ORDER BY id`, prefix+"%")
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		var namespaces []Namespace
-		for rows.Next() {
-			var ns Namespace
-			if err := rows.Scan(&ns.ID, &ns.DisplayName, &ns.Active, &ns.MaxInstructors, &ns.MaxStudents, &ns.CreatedAt, &ns.CreatedBy, &ns.UpdatedAt); err != nil {
-				return nil, err
-			}
-			namespaces = append(namespaces, ns)
-		}
-		return namespaces, rows.Err()
-	}
-
-	t.Run("empty result", func(t *testing.T) {
-		results, err := listNamespaces()
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(results) != 0 {
-			t.Errorf("expected 0 namespaces, got %d", len(results))
-		}
+	db.createNamespace(ctx, t, nsB, "NS B")
+	db.createNamespace(ctx, t, nsA, "NS A")
+	db.createNamespace(ctx, t, nsC, "NS C")
+	t.Cleanup(func() {
+		_, _ = db.pool.Exec(ctx, "DELETE FROM namespaces WHERE id IN ($1, $2, $3)", nsA, nsB, nsC)
 	})
 
-	t.Run("multiple records ordered by id", func(t *testing.T) {
-		db.createNamespace(ctx, t, nsB, "NS B")
-		db.createNamespace(ctx, t, nsA, "NS A")
-		db.createNamespace(ctx, t, nsC, "NS C")
-		t.Cleanup(func() {
-			_, _ = db.pool.Exec(ctx, "DELETE FROM namespaces WHERE id IN ($1, $2, $3)", nsA, nsB, nsC)
-		})
+	t.Run("system admin sees all namespaces", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
 
-		results, err := listNamespaces()
+		results, err := s.ListNamespaces(ctx)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(results) != 3 {
-			t.Fatalf("expected 3 namespaces, got %d", len(results))
-		}
-		if results[0].ID != nsA || results[1].ID != nsB || results[2].ID != nsC {
-			t.Errorf("expected order %s, %s, %s, got %s, %s, %s", nsA, nsB, nsC, results[0].ID, results[1].ID, results[2].ID)
+		// Should see at least db.nsID plus nsA, nsB, nsC (4 total minimum)
+		if len(results) < 4 {
+			t.Errorf("expected at least 4 namespaces, got %d", len(results))
 		}
 	})
 }
@@ -196,34 +201,31 @@ func TestIntegration_UpdateNamespace(t *testing.T) {
 	defer db.close()
 	ctx := context.Background()
 
-	conn, err := db.pool.Acquire(ctx)
+	// System admin is required to update namespaces per RLS policy
+	adminID := uuid.New()
+	_, err := db.pool.Exec(ctx,
+		`INSERT INTO users (id, email, role) VALUES ($1, $2, $3)`,
+		adminID, "sysadmin@test.com", "system-admin")
 	if err != nil {
-		t.Fatalf("acquire: %v", err)
+		t.Fatalf("create admin: %v", err)
 	}
-	defer conn.Release()
+	t.Cleanup(func() {
+		_, _ = db.pool.Exec(ctx, "DELETE FROM users WHERE id = $1", adminID)
+	})
 
-	updateNamespace := func(id string, params UpdateNamespaceParams) (*Namespace, error) {
-		var ns Namespace
-		err := conn.QueryRow(ctx,
-			`UPDATE namespaces
-			 SET display_name    = COALESCE($2, display_name),
-			     active          = COALESCE($3, active),
-			     max_instructors = COALESCE($4, max_instructors),
-			     max_students    = COALESCE($5, max_students),
-			     updated_at      = now()
-			 WHERE id = $1
-			 RETURNING id, display_name, active, max_instructors, max_students, created_at, created_by, updated_at`,
-			id, params.DisplayName, params.Active, params.MaxInstructors, params.MaxStudents,
-		).Scan(&ns.ID, &ns.DisplayName, &ns.Active, &ns.MaxInstructors, &ns.MaxStudents, &ns.CreatedAt, &ns.CreatedBy, &ns.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &ns, nil
+	authUser := &auth.User{
+		ID:          adminID,
+		Email:       "sysadmin@test.com",
+		NamespaceID: "",
+		Role:        auth.RoleSystemAdmin,
 	}
 
 	t.Run("partial update display_name only", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newName := "Updated Name"
-		ns, err := updateNamespace(db.nsID, UpdateNamespaceParams{DisplayName: &newName})
+		ns, err := s.UpdateNamespace(ctx, db.nsID, UpdateNamespaceParams{DisplayName: &newName})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -236,8 +238,11 @@ func TestIntegration_UpdateNamespace(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newName := "Whatever"
-		_, err := updateNamespace("nonexistent-"+uuid.New().String(), UpdateNamespaceParams{DisplayName: &newName})
+		_, err := s.UpdateNamespace(ctx, "nonexistent-"+uuid.New().String(), UpdateNamespaceParams{DisplayName: &newName})
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -245,7 +250,7 @@ func TestIntegration_UpdateNamespace(t *testing.T) {
 }
 
 // =============================================================================
-// Class CRUD Tests
+// Class CRUD Tests - calls actual Store methods with RLS
 // =============================================================================
 
 func TestIntegration_CreateClass(t *testing.T) {
@@ -254,25 +259,27 @@ func TestIntegration_CreateClass(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
-	defer conn.Release()
 
 	t.Run("successful creation", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		desc := "A test class"
-		var c Class
-		err := conn.QueryRow(ctx,
-			`INSERT INTO classes (namespace_id, name, description, created_by)
-			 VALUES ($1, $2, $3, $4)
-			 RETURNING id, namespace_id, name, description, created_by, created_at, updated_at`,
-			nsID, "CS101", &desc, createdBy,
-		).Scan(&c.ID, &c.NamespaceID, &c.Name, &c.Description, &c.CreatedBy, &c.CreatedAt, &c.UpdatedAt)
+		c, err := s.CreateClass(ctx, CreateClassParams{
+			NamespaceID: nsID,
+			Name:        "CS101",
+			Description: &desc,
+			CreatedBy:   createdBy,
+		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -295,17 +302,6 @@ func TestIntegration_CreateClass(t *testing.T) {
 			t.Error("expected non-zero created_at")
 		}
 	})
-
-	t.Run("record exists after creation", func(t *testing.T) {
-		var count int
-		err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM classes WHERE namespace_id = $1", nsID).Scan(&count)
-		if err != nil {
-			t.Fatalf("query: %v", err)
-		}
-		if count != 1 {
-			t.Errorf("expected 1 record, got %d", count)
-		}
-	})
 }
 
 func TestIntegration_GetClass(t *testing.T) {
@@ -314,32 +310,23 @@ func TestIntegration_GetClass(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-get-class"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", createdBy)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getClass := func(id uuid.UUID) (*Class, error) {
-		var c Class
-		err := conn.QueryRow(ctx,
-			`SELECT id, namespace_id, name, description, created_by, created_at, updated_at
-			 FROM classes WHERE id = $1`, id).Scan(
-			&c.ID, &c.NamespaceID, &c.Name, &c.Description, &c.CreatedBy, &c.CreatedAt, &c.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &c, nil
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		c, err := getClass(classID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		c, err := s.GetClass(ctx, classID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -355,7 +342,10 @@ func TestIntegration_GetClass(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getClass(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetClass(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -368,37 +358,21 @@ func TestIntegration_ListClasses(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-list-classes"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listClasses := func() ([]Class, error) {
-		rows, err := conn.Query(ctx,
-			`SELECT id, namespace_id, name, description, created_by, created_at, updated_at
-			 FROM classes WHERE namespace_id = $1 ORDER BY created_at`, nsID)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		var classes []Class
-		for rows.Next() {
-			var c Class
-			if err := rows.Scan(&c.ID, &c.NamespaceID, &c.Name, &c.Description, &c.CreatedBy, &c.CreatedAt, &c.UpdatedAt); err != nil {
-				return nil, err
-			}
-			classes = append(classes, c)
-		}
-		return classes, rows.Err()
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
-	t.Run("empty result", func(t *testing.T) {
-		results, err := listClasses()
+	t.Run("empty result before creation", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListClasses(ctx)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -414,7 +388,10 @@ func TestIntegration_ListClasses(t *testing.T) {
 		c2 := uuid.New()
 		db.createClass(ctx, t, c2, nsID, "CS201", createdBy)
 
-		results, err := listClasses()
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListClasses(ctx)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -433,38 +410,24 @@ func TestIntegration_UpdateClass(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-update-class"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", createdBy)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	updateClass := func(id uuid.UUID, params UpdateClassParams) (*Class, error) {
-		var c Class
-		err := conn.QueryRow(ctx,
-			`UPDATE classes
-			 SET name        = COALESCE($2, name),
-			     description = COALESCE($3, description),
-			     updated_at  = now()
-			 WHERE id = $1
-			 RETURNING id, namespace_id, name, description, created_by, created_at, updated_at`,
-			id, params.Name, params.Description,
-		).Scan(&c.ID, &c.NamespaceID, &c.Name, &c.Description, &c.CreatedBy, &c.CreatedAt, &c.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &c, nil
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("partial update name only", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newName := "CS102"
-		c, err := updateClass(classID, UpdateClassParams{Name: &newName})
+		c, err := s.UpdateClass(ctx, classID, UpdateClassParams{Name: &newName})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -474,8 +437,11 @@ func TestIntegration_UpdateClass(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newName := "Whatever"
-		_, err := updateClass(uuid.New(), UpdateClassParams{Name: &newName})
+		_, err := s.UpdateClass(ctx, uuid.New(), UpdateClassParams{Name: &newName})
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -488,35 +454,27 @@ func TestIntegration_DeleteClass(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-delete-class"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", createdBy)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	deleteClass := func(id uuid.UUID) error {
-		tag, err := conn.Exec(ctx, "DELETE FROM classes WHERE id = $1", id)
-		if err != nil {
-			return err
-		}
-		if tag.RowsAffected() == 0 {
-			return ErrNotFound
-		}
-		return nil
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("successful deletion", func(t *testing.T) {
-		if err := deleteClass(classID); err != nil {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		if err := s.DeleteClass(ctx, classID); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		var count int
-		if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM classes WHERE id = $1", classID).Scan(&count); err != nil {
+		if err := db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM classes WHERE id = $1", classID).Scan(&count); err != nil {
 			t.Fatalf("count query: %v", err)
 		}
 		if count != 0 {
@@ -525,7 +483,10 @@ func TestIntegration_DeleteClass(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		err := deleteClass(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		err := s.DeleteClass(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -533,7 +494,7 @@ func TestIntegration_DeleteClass(t *testing.T) {
 }
 
 // =============================================================================
-// Section CRUD Tests
+// Section CRUD Tests - calls actual Store methods with RLS
 // =============================================================================
 
 func TestIntegration_CreateSection(t *testing.T) {
@@ -542,27 +503,31 @@ func TestIntegration_CreateSection(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-create-section"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", createdBy)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
-	defer conn.Release()
 
 	t.Run("successful creation", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		semester := "Fall 2025"
-		var sec Section
-		err := conn.QueryRow(ctx,
-			`INSERT INTO sections (namespace_id, class_id, name, semester, join_code)
-			 VALUES ($1, $2, $3, $4, $5)
-			 RETURNING id, namespace_id, class_id, name, semester, join_code, active, created_at, updated_at`,
-			nsID, classID, "Section A", &semester, "JOIN-CREATE",
-		).Scan(&sec.ID, &sec.NamespaceID, &sec.ClassID, &sec.Name, &sec.Semester, &sec.JoinCode, &sec.Active, &sec.CreatedAt, &sec.UpdatedAt)
+		joinCode := "JOIN-CREATE-" + uuid.New().String()[:8] // unique join code
+		sec, err := s.CreateSection(ctx, CreateSectionParams{
+			NamespaceID: nsID,
+			ClassID:     classID,
+			Name:        "Section A",
+			Semester:    &semester,
+			JoinCode:    joinCode,
+		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -578,25 +543,14 @@ func TestIntegration_CreateSection(t *testing.T) {
 		if sec.Semester == nil || *sec.Semester != "Fall 2025" {
 			t.Errorf("expected semester 'Fall 2025', got %v", sec.Semester)
 		}
-		if sec.JoinCode != "JOIN-CREATE" {
-			t.Errorf("expected join_code JOIN-CREATE, got %s", sec.JoinCode)
+		if sec.JoinCode != joinCode {
+			t.Errorf("expected join_code %s, got %s", joinCode, sec.JoinCode)
 		}
 		if !sec.Active {
 			t.Error("expected active to be true by default")
 		}
 		if sec.ID == uuid.Nil {
 			t.Error("expected non-nil UUID id")
-		}
-	})
-
-	t.Run("record exists after creation", func(t *testing.T) {
-		var count int
-		err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM sections WHERE class_id = $1", classID).Scan(&count)
-		if err != nil {
-			t.Fatalf("query: %v", err)
-		}
-		if count != 1 {
-			t.Errorf("expected 1 record, got %d", count)
 		}
 	})
 }
@@ -607,7 +561,6 @@ func TestIntegration_GetSection(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-get-section"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
@@ -615,26 +568,18 @@ func TestIntegration_GetSection(t *testing.T) {
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN-GET")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getSection := func(id uuid.UUID) (*Section, error) {
-		var sec Section
-		err := conn.QueryRow(ctx,
-			`SELECT id, namespace_id, class_id, name, semester, join_code, active, created_at, updated_at
-			 FROM sections WHERE id = $1`, id).Scan(
-			&sec.ID, &sec.NamespaceID, &sec.ClassID, &sec.Name, &sec.Semester, &sec.JoinCode, &sec.Active, &sec.CreatedAt, &sec.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &sec, nil
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		sec, err := getSection(sectionID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		sec, err := s.GetSection(ctx, sectionID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -644,13 +589,17 @@ func TestIntegration_GetSection(t *testing.T) {
 		if sec.Name != "Section A" {
 			t.Errorf("expected name 'Section A', got %s", sec.Name)
 		}
-		if sec.JoinCode != "JOIN-GET" {
-			t.Errorf("expected join_code JOIN-GET, got %s", sec.JoinCode)
+		expectedJoinCode := uniqueJoinCode(sectionID, "JOIN-GET")
+		if sec.JoinCode != expectedJoinCode {
+			t.Errorf("expected join_code %s, got %s", expectedJoinCode, sec.JoinCode)
 		}
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getSection(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetSection(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -663,39 +612,23 @@ func TestIntegration_ListSectionsByClass(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-list-sections"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", createdBy)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listSectionsByClass := func(cid uuid.UUID) ([]Section, error) {
-		rows, err := conn.Query(ctx,
-			`SELECT id, namespace_id, class_id, name, semester, join_code, active, created_at, updated_at
-			 FROM sections WHERE class_id = $1 ORDER BY created_at`, cid)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		var sections []Section
-		for rows.Next() {
-			var sec Section
-			if err := rows.Scan(&sec.ID, &sec.NamespaceID, &sec.ClassID, &sec.Name, &sec.Semester, &sec.JoinCode, &sec.Active, &sec.CreatedAt, &sec.UpdatedAt); err != nil {
-				return nil, err
-			}
-			sections = append(sections, sec)
-		}
-		return sections, rows.Err()
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("empty result", func(t *testing.T) {
-		results, err := listSectionsByClass(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListSectionsByClass(ctx, uuid.New())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -711,7 +644,10 @@ func TestIntegration_ListSectionsByClass(t *testing.T) {
 		s2 := uuid.New()
 		db.createSection(ctx, t, s2, nsID, classID, "Section B", "JOIN-LIST-2")
 
-		results, err := listSectionsByClass(classID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListSectionsByClass(ctx, classID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -730,41 +666,28 @@ func TestIntegration_UpdateSection(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-update-section"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", createdBy)
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN-UPDATE")
+	// RLS requires user to be section instructor to update/delete sections
+	db.createMembership(ctx, t, createdBy, sectionID, "instructor")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	updateSection := func(id uuid.UUID, params UpdateSectionParams) (*Section, error) {
-		var sec Section
-		err := conn.QueryRow(ctx,
-			`UPDATE sections
-			 SET name       = COALESCE($2, name),
-			     semester   = COALESCE($3, semester),
-			     active     = COALESCE($4, active),
-			     updated_at = now()
-			 WHERE id = $1
-			 RETURNING id, namespace_id, class_id, name, semester, join_code, active, created_at, updated_at`,
-			id, params.Name, params.Semester, params.Active,
-		).Scan(&sec.ID, &sec.NamespaceID, &sec.ClassID, &sec.Name, &sec.Semester, &sec.JoinCode, &sec.Active, &sec.CreatedAt, &sec.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &sec, nil
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("partial update name only", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newName := "Section B"
-		sec, err := updateSection(sectionID, UpdateSectionParams{Name: &newName})
+		sec, err := s.UpdateSection(ctx, sectionID, UpdateSectionParams{Name: &newName})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -777,8 +700,11 @@ func TestIntegration_UpdateSection(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newName := "Whatever"
-		_, err := updateSection(uuid.New(), UpdateSectionParams{Name: &newName})
+		_, err := s.UpdateSection(ctx, uuid.New(), UpdateSectionParams{Name: &newName})
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -791,37 +717,31 @@ func TestIntegration_DeleteSection(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-delete-section"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", createdBy)
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN-DELETE")
+	// RLS requires user to be section instructor to delete sections
+	db.createMembership(ctx, t, createdBy, sectionID, "instructor")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	deleteSection := func(id uuid.UUID) error {
-		tag, err := conn.Exec(ctx, "DELETE FROM sections WHERE id = $1", id)
-		if err != nil {
-			return err
-		}
-		if tag.RowsAffected() == 0 {
-			return ErrNotFound
-		}
-		return nil
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("successful deletion", func(t *testing.T) {
-		if err := deleteSection(sectionID); err != nil {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		if err := s.DeleteSection(ctx, sectionID); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		var count int
-		if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM sections WHERE id = $1", sectionID).Scan(&count); err != nil {
+		if err := db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM sections WHERE id = $1", sectionID).Scan(&count); err != nil {
 			t.Fatalf("count query: %v", err)
 		}
 		if count != 0 {
@@ -830,7 +750,10 @@ func TestIntegration_DeleteSection(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		err := deleteSection(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		err := s.DeleteSection(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -838,7 +761,7 @@ func TestIntegration_DeleteSection(t *testing.T) {
 }
 
 // =============================================================================
-// Membership CRUD Tests
+// Membership CRUD Tests - calls actual Store methods with RLS
 // =============================================================================
 
 func TestIntegration_CreateMembership(t *testing.T) {
@@ -847,7 +770,6 @@ func TestIntegration_CreateMembership(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-create-membership"
 
 	userID := uuid.New()
 	db.createUser(ctx, t, userID, "member@test.com", "student", nsID)
@@ -858,28 +780,18 @@ func TestIntegration_CreateMembership(t *testing.T) {
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN-MEMBER")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	createMembership := func(params CreateMembershipParams) (*SectionMembership, error) {
-		var m SectionMembership
-		err := conn.QueryRow(ctx,
-			`INSERT INTO section_memberships (user_id, section_id, role)
-			 VALUES ($1, $2, $3)
-			 RETURNING id, user_id, section_id, role, joined_at`,
-			params.UserID, params.SectionID, params.Role,
-		).Scan(&m.ID, &m.UserID, &m.SectionID, &m.Role, &m.JoinedAt)
-		if err != nil {
-			return nil, HandleDuplicate(err)
-		}
-		return &m, nil
+	authUser := &auth.User{
+		ID:          userID,
+		Email:       "member@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleStudent,
 	}
 
 	t.Run("successful creation", func(t *testing.T) {
-		m, err := createMembership(CreateMembershipParams{UserID: userID, SectionID: sectionID, Role: "student"})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		m, err := s.CreateMembership(ctx, CreateMembershipParams{UserID: userID, SectionID: sectionID, Role: "student"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -901,7 +813,10 @@ func TestIntegration_CreateMembership(t *testing.T) {
 	})
 
 	t.Run("duplicate returns ErrDuplicate", func(t *testing.T) {
-		_, err := createMembership(CreateMembershipParams{UserID: userID, SectionID: sectionID, Role: "student"})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.CreateMembership(ctx, CreateMembershipParams{UserID: userID, SectionID: sectionID, Role: "student"})
 		if !errors.Is(err, ErrDuplicate) {
 			t.Errorf("expected ErrDuplicate, got: %v", err)
 		}
@@ -914,47 +829,42 @@ func TestIntegration_GetSectionByJoinCode(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-joincode-get"
 	createdBy := uuid.New()
 	db.createUser(ctx, t, createdBy, "creator@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", createdBy)
 	sectionID := uuid.New()
-	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "UNIQUE-JOIN-CODE")
+	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "UNIQUE")
+	expectedJoinCode := uniqueJoinCode(sectionID, "UNIQUE")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getSectionByJoinCode := func(code string) (*Section, error) {
-		var sec Section
-		err := conn.QueryRow(ctx,
-			`SELECT id, namespace_id, class_id, name, semester, join_code, active, created_at, updated_at
-			 FROM sections WHERE join_code = $1`, code).Scan(
-			&sec.ID, &sec.NamespaceID, &sec.ClassID, &sec.Name, &sec.Semester, &sec.JoinCode, &sec.Active, &sec.CreatedAt, &sec.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &sec, nil
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		sec, err := getSectionByJoinCode("UNIQUE-JOIN-CODE")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		sec, err := s.GetSectionByJoinCode(ctx, expectedJoinCode)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if sec.ID != sectionID {
 			t.Errorf("expected id %s, got %s", sectionID, sec.ID)
 		}
-		if sec.JoinCode != "UNIQUE-JOIN-CODE" {
-			t.Errorf("expected join_code UNIQUE-JOIN-CODE, got %s", sec.JoinCode)
+		if sec.JoinCode != expectedJoinCode {
+			t.Errorf("expected join_code %s, got %s", expectedJoinCode, sec.JoinCode)
 		}
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getSectionByJoinCode("NONEXISTENT-CODE")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetSectionByJoinCode(ctx, "NONEXISTENT-CODE-"+uuid.New().String()[:8])
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -967,7 +877,6 @@ func TestIntegration_DeleteMembership(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-delete-membership"
 
 	userID := uuid.New()
 	db.createUser(ctx, t, userID, "member@test.com", "student", nsID)
@@ -978,31 +887,25 @@ func TestIntegration_DeleteMembership(t *testing.T) {
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN-DEL-MEM")
 	db.createMembership(ctx, t, userID, sectionID, "student")
+	// RLS requires instructor to be a section instructor to delete memberships
+	db.createMembership(ctx, t, createdBy, sectionID, "instructor")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	deleteMembership := func(secID, uid uuid.UUID) error {
-		tag, err := conn.Exec(ctx,
-			"DELETE FROM section_memberships WHERE section_id = $1 AND user_id = $2", secID, uid)
-		if err != nil {
-			return err
-		}
-		if tag.RowsAffected() == 0 {
-			return ErrNotFound
-		}
-		return nil
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("successful deletion", func(t *testing.T) {
-		if err := deleteMembership(sectionID, userID); err != nil {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		if err := s.DeleteMembership(ctx, sectionID, userID); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		var count int
-		if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM section_memberships WHERE section_id = $1 AND user_id = $2", sectionID, userID).Scan(&count); err != nil {
+		if err := db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM section_memberships WHERE section_id = $1 AND user_id = $2", sectionID, userID).Scan(&count); err != nil {
 			t.Fatalf("count query: %v", err)
 		}
 		if count != 0 {
@@ -1011,7 +914,10 @@ func TestIntegration_DeleteMembership(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		err := deleteMembership(sectionID, uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		err := s.DeleteMembership(ctx, sectionID, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -1024,7 +930,6 @@ func TestIntegration_ListMembers(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// namespace scoped to db.nsID (was "test-ns-list-members"
 
 	user1 := uuid.New()
 	user2 := uuid.New()
@@ -1037,33 +942,18 @@ func TestIntegration_ListMembers(t *testing.T) {
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN-LIST-MEM")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listMembers := func(secID uuid.UUID) ([]SectionMembership, error) {
-		rows, err := conn.Query(ctx,
-			`SELECT id, user_id, section_id, role, joined_at
-			 FROM section_memberships WHERE section_id = $1 ORDER BY joined_at`, secID)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		var members []SectionMembership
-		for rows.Next() {
-			var m SectionMembership
-			if err := rows.Scan(&m.ID, &m.UserID, &m.SectionID, &m.Role, &m.JoinedAt); err != nil {
-				return nil, err
-			}
-			members = append(members, m)
-		}
-		return members, rows.Err()
+	authUser := &auth.User{
+		ID:          createdBy,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("empty result", func(t *testing.T) {
-		results, err := listMembers(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListMembers(ctx, uuid.New())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1078,7 +968,10 @@ func TestIntegration_ListMembers(t *testing.T) {
 		db.createMembership(ctx, t, user2, sectionID, "student")
 		db.createMembership(ctx, t, createdBy, sectionID, "instructor")
 
-		results, err := listMembers(sectionID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListMembers(ctx, sectionID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/go-backend/internal/store/store_methods_integration_test.go
+++ b/go-backend/internal/store/store_methods_integration_test.go
@@ -1,9 +1,8 @@
 // Integration tests for store methods added in PR #24.
 //
-// These tests validate the SQL queries and scanning logic by executing them
-// directly against a running PostgreSQL database. They bypass the Store.conn()
-// middleware-context mechanism and use the pool directly as a Querier, which
-// tests the same SQL and row-scanning code paths.
+// These tests validate actual Store methods with proper RLS context,
+// ensuring that the SQL queries, scanning logic, and RLS policies work
+// together as they would in production.
 //
 // Run with:
 //
@@ -22,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jdelfino/eval/internal/auth"
 )
 
 // integrationDB wraps a pool for integration tests and provides helper methods.
@@ -50,6 +50,12 @@ func setupIntegrationDB(t *testing.T) *integrationDB {
 		t.Fatalf("failed to ping database: %v", err)
 	}
 
+	// Ensure eval_app role exists for RLS testing
+	if err := ensureEvalAppRole(ctx, pool); err != nil {
+		pool.Close()
+		t.Fatalf("failed to ensure eval_app role: %v", err)
+	}
+
 	nsID := "ns-" + uuid.New().String()
 	_, err = pool.Exec(ctx,
 		`INSERT INTO namespaces (id, display_name, active) VALUES ($1, $2, true)`,
@@ -65,6 +71,49 @@ func setupIntegrationDB(t *testing.T) *integrationDB {
 		idb.close()
 	})
 	return idb
+}
+
+// ensureEvalAppRole creates the eval_app role if it doesn't exist.
+// This role is used for RLS testing because superusers bypass RLS policies.
+func ensureEvalAppRole(ctx context.Context, pool *pgxpool.Pool) error {
+	_, err := pool.Exec(ctx, `
+		DO $$
+		BEGIN
+			IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'eval_app') THEN
+				CREATE ROLE eval_app WITH LOGIN PASSWORD 'eval_app_password' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+			END IF;
+		END $$
+	`)
+	if err != nil {
+		return fmt.Errorf("create role: %w", err)
+	}
+
+	_, err = pool.Exec(ctx, "GRANT CONNECT ON DATABASE eval TO eval_app")
+	if err != nil {
+		return fmt.Errorf("grant connect: %w", err)
+	}
+
+	_, err = pool.Exec(ctx, "GRANT USAGE ON SCHEMA public TO eval_app")
+	if err != nil {
+		return fmt.Errorf("grant usage: %w", err)
+	}
+
+	_, err = pool.Exec(ctx, "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO eval_app")
+	if err != nil {
+		return fmt.Errorf("grant table privileges: %w", err)
+	}
+
+	_, err = pool.Exec(ctx, "GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO eval_app")
+	if err != nil {
+		return fmt.Errorf("grant sequence privileges: %w", err)
+	}
+
+	_, err = pool.Exec(ctx, "GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO eval_app")
+	if err != nil {
+		return fmt.Errorf("grant function privileges: %w", err)
+	}
+
+	return nil
 }
 
 func (db *integrationDB) close() {
@@ -83,11 +132,75 @@ func (db *integrationDB) cleanup(ctx context.Context, t *testing.T) {
 	}
 }
 
+// setRLSContext sets the PostgreSQL session variables for RLS.
+// It also sets the role to 'eval_app' so that RLS policies are enforced
+// (superusers bypass RLS).
+func (db *integrationDB) setRLSContext(ctx context.Context, conn *pgxpool.Conn, user *auth.User) error {
+	_, err := conn.Exec(ctx, "SET ROLE eval_app")
+	if err != nil {
+		return fmt.Errorf("set role to eval_app: %w", err)
+	}
+
+	_, err = conn.Exec(ctx, "SELECT set_config('app.user_id', $1, false)", user.ID.String())
+	if err != nil {
+		return fmt.Errorf("set user_id: %w", err)
+	}
+
+	_, err = conn.Exec(ctx, "SELECT set_config('app.namespace_id', $1, false)", user.NamespaceID)
+	if err != nil {
+		return fmt.Errorf("set namespace_id: %w", err)
+	}
+
+	_, err = conn.Exec(ctx, "SELECT set_config('app.role', $1, false)", string(user.Role))
+	if err != nil {
+		return fmt.Errorf("set role: %w", err)
+	}
+
+	return nil
+}
+
+// storeWithRLS acquires a connection, sets RLS context, and returns a Store.
+// The caller must release the connection.
+func (db *integrationDB) storeWithRLS(ctx context.Context, t *testing.T, user *auth.User) (*Store, *pgxpool.Conn) {
+	t.Helper()
+	conn, err := db.pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire connection: %v", err)
+	}
+
+	if err := db.setRLSContext(ctx, conn, user); err != nil {
+		conn.Release()
+		t.Fatalf("set RLS context: %v", err)
+	}
+
+	return New(conn), conn
+}
+
+// execAsSuperuser runs SQL as superuser by resetting the role first.
+// This is needed because connections returned to the pool may still have
+// SET ROLE eval_app from previous RLS testing.
+func (db *integrationDB) execAsSuperuser(ctx context.Context, sql string, args ...interface{}) error {
+	conn, err := db.pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+
+	// Reset to superuser role (the pool's default user)
+	_, err = conn.Exec(ctx, "RESET ROLE")
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.Exec(ctx, sql, args...)
+	return err
+}
+
 // seed helpers
 
 func (db *integrationDB) createNamespace(ctx context.Context, t *testing.T, id, displayName string) {
 	t.Helper()
-	_, err := db.pool.Exec(ctx,
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO namespaces (id, display_name, active) VALUES ($1, $2, true)`, id, displayName)
 	if err != nil {
 		t.Fatalf("create namespace %s: %v", id, err)
@@ -100,7 +213,7 @@ func (db *integrationDB) createUser(ctx context.Context, t *testing.T, id uuid.U
 	if nsID != "" {
 		ns = &nsID
 	}
-	_, err := db.pool.Exec(ctx,
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO users (id, email, role, namespace_id) VALUES ($1, $2, $3, $4)`,
 		id, email, role, ns)
 	if err != nil {
@@ -114,7 +227,7 @@ func (db *integrationDB) createUserWithDisplayName(ctx context.Context, t *testi
 	if nsID != "" {
 		ns = &nsID
 	}
-	_, err := db.pool.Exec(ctx,
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO users (id, email, role, namespace_id, display_name) VALUES ($1, $2, $3, $4, $5)`,
 		id, email, role, ns, displayName)
 	if err != nil {
@@ -124,7 +237,7 @@ func (db *integrationDB) createUserWithDisplayName(ctx context.Context, t *testi
 
 func (db *integrationDB) createClass(ctx context.Context, t *testing.T, id uuid.UUID, nsID, name string, createdBy uuid.UUID) {
 	t.Helper()
-	_, err := db.pool.Exec(ctx,
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO classes (id, namespace_id, name, created_by) VALUES ($1, $2, $3, $4)`,
 		id, nsID, name, createdBy)
 	if err != nil {
@@ -132,9 +245,16 @@ func (db *integrationDB) createClass(ctx context.Context, t *testing.T, id uuid.
 	}
 }
 
-func (db *integrationDB) createSection(ctx context.Context, t *testing.T, id uuid.UUID, nsID string, classID uuid.UUID, name, joinCode string) {
+// uniqueJoinCode generates a unique join code using the section ID.
+func uniqueJoinCode(sectionID uuid.UUID, prefix string) string {
+	return prefix + "-" + sectionID.String()[:8]
+}
+
+func (db *integrationDB) createSection(ctx context.Context, t *testing.T, id uuid.UUID, nsID string, classID uuid.UUID, name, joinCodePrefix string) {
 	t.Helper()
-	_, err := db.pool.Exec(ctx,
+	// Generate unique join code using section ID to avoid conflicts across test runs
+	joinCode := uniqueJoinCode(id, joinCodePrefix)
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO sections (id, namespace_id, class_id, name, join_code) VALUES ($1, $2, $3, $4, $5)`,
 		id, nsID, classID, name, joinCode)
 	if err != nil {
@@ -144,7 +264,7 @@ func (db *integrationDB) createSection(ctx context.Context, t *testing.T, id uui
 
 func (db *integrationDB) createMembership(ctx context.Context, t *testing.T, userID, sectionID uuid.UUID, role string) {
 	t.Helper()
-	_, err := db.pool.Exec(ctx,
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO section_memberships (user_id, section_id, role) VALUES ($1, $2, $3)`,
 		userID, sectionID, role)
 	if err != nil {
@@ -154,7 +274,7 @@ func (db *integrationDB) createMembership(ctx context.Context, t *testing.T, use
 
 func (db *integrationDB) createProblem(ctx context.Context, t *testing.T, id uuid.UUID, nsID, title string, authorID uuid.UUID, classID *uuid.UUID, tags []string) {
 	t.Helper()
-	_, err := db.pool.Exec(ctx,
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO problems (id, namespace_id, title, test_cases, execution_settings, author_id, class_id, tags)
 		 VALUES ($1, $2, $3, '{}', '{}', $4, $5, $6)`,
 		id, nsID, title, authorID, classID, tags)
@@ -164,7 +284,7 @@ func (db *integrationDB) createProblem(ctx context.Context, t *testing.T, id uui
 }
 
 // =============================================================================
-// Test: ListProblemsFiltered
+// Test: ListProblemsFiltered - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListProblemsFiltered(t *testing.T) {
@@ -191,104 +311,74 @@ func TestIntegration_ListProblemsFiltered(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	db.createProblem(ctx, t, p3, nsID, "Charlie Problem", authorID, &classID, []string{"easy", "strings"})
 
-	// Use pool directly as Querier
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	// Create auth user for RLS context
+	authUser := &auth.User{
+		ID:          authorID,
+		Email:       "author@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
-	defer conn.Release()
 
-	// Helper to run the ListProblemsFiltered query directly
-	runFiltered := func(t *testing.T, filters ProblemFilters) []Problem {
-		t.Helper()
-		query := `
-			SELECT id, namespace_id, title, description, starter_code, test_cases,
-			       execution_settings, author_id, class_id, tags, solution, created_at, updated_at
-			FROM problems WHERE 1=1`
-		var args []any
-		argIdx := 1
+	t.Run("no filters returns all in namespace", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
 
-		if filters.ClassID != nil {
-			query += fmt.Sprintf(" AND class_id = $%d", argIdx)
-			args = append(args, *filters.ClassID)
-			argIdx++
-		}
-		if filters.AuthorID != nil {
-			query += fmt.Sprintf(" AND author_id = $%d", argIdx)
-			args = append(args, *filters.AuthorID)
-			argIdx++
-		}
-		if len(filters.Tags) > 0 {
-			query += fmt.Sprintf(" AND tags && $%d", argIdx)
-			args = append(args, filters.Tags)
-		}
-		if filters.PublicOnly {
-			query += " AND class_id IS NULL"
-		}
-		sortBy := "created_at"
-		switch filters.SortBy {
-		case "title":
-			sortBy = "title"
-		case "updated_at":
-			sortBy = "updated_at"
-		}
-		sortOrder := "ASC"
-		if filters.SortOrder == "desc" {
-			sortOrder = "DESC"
-		}
-		query += fmt.Sprintf(" ORDER BY %s %s", sortBy, sortOrder)
-
-		rows, err := conn.Query(ctx, query, args...)
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{})
 		if err != nil {
-			t.Fatalf("query: %v", err)
+			t.Fatalf("ListProblemsFiltered: %v", err)
 		}
-		defer rows.Close()
-		var problems []Problem
-		for rows.Next() {
-			var p Problem
-			if err := rows.Scan(&p.ID, &p.NamespaceID, &p.Title, &p.Description, &p.StarterCode,
-				&p.TestCases, &p.ExecutionSettings, &p.AuthorID, &p.ClassID, &p.Tags, &p.Solution,
-				&p.CreatedAt, &p.UpdatedAt); err != nil {
-				t.Fatalf("scan: %v", err)
-			}
-			problems = append(problems, p)
-		}
-		if err := rows.Err(); err != nil {
-			t.Fatalf("rows err: %v", err)
-		}
-		return problems
-	}
-
-	t.Run("no filters returns all", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{})
 		if len(results) != 3 {
 			t.Errorf("expected 3 problems, got %d", len(results))
 		}
 	})
 
 	t.Run("filter by class_id", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{ClassID: &classID})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{ClassID: &classID})
+		if err != nil {
+			t.Fatalf("ListProblemsFiltered: %v", err)
+		}
 		if len(results) != 2 {
 			t.Errorf("expected 2 problems in class, got %d", len(results))
 		}
 	})
 
 	t.Run("filter by author_id", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{AuthorID: &authorID})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{AuthorID: &authorID})
+		if err != nil {
+			t.Fatalf("ListProblemsFiltered: %v", err)
+		}
 		if len(results) != 2 {
 			t.Errorf("expected 2 problems by author, got %d", len(results))
 		}
 	})
 
 	t.Run("filter by tags", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{Tags: []string{"easy"}})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{Tags: []string{"easy"}})
+		if err != nil {
+			t.Fatalf("ListProblemsFiltered: %v", err)
+		}
 		if len(results) != 2 {
 			t.Errorf("expected 2 easy problems, got %d", len(results))
 		}
 	})
 
 	t.Run("public_only", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{PublicOnly: true})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{PublicOnly: true})
+		if err != nil {
+			t.Fatalf("ListProblemsFiltered: %v", err)
+		}
 		if len(results) != 1 {
 			t.Errorf("expected 1 public problem, got %d", len(results))
 		}
@@ -298,28 +388,52 @@ func TestIntegration_ListProblemsFiltered(t *testing.T) {
 	})
 
 	t.Run("sort by title asc", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{SortBy: "title"})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{SortBy: "title"})
+		if err != nil {
+			t.Fatalf("ListProblemsFiltered: %v", err)
+		}
 		if len(results) >= 2 && results[0].Title > results[1].Title {
 			t.Errorf("expected ascending title order, got %s before %s", results[0].Title, results[1].Title)
 		}
 	})
 
 	t.Run("sort by title desc", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{SortBy: "title", SortOrder: "desc"})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{SortBy: "title", SortOrder: "desc"})
+		if err != nil {
+			t.Fatalf("ListProblemsFiltered: %v", err)
+		}
 		if len(results) >= 2 && results[0].Title < results[1].Title {
 			t.Errorf("expected descending title order, got %s before %s", results[0].Title, results[1].Title)
 		}
 	})
 
 	t.Run("combined filters: class + tags", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{ClassID: &classID, Tags: []string{"easy"}})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{ClassID: &classID, Tags: []string{"easy"}})
+		if err != nil {
+			t.Fatalf("ListProblemsFiltered: %v", err)
+		}
 		if len(results) != 2 {
 			t.Errorf("expected 2 problems matching class+tags, got %d", len(results))
 		}
 	})
 
 	t.Run("invalid sort_by defaults to created_at", func(t *testing.T) {
-		results := runFiltered(t, ProblemFilters{SortBy: "invalid_column"})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblemsFiltered(ctx, ProblemFilters{SortBy: "invalid_column"})
+		if err != nil {
+			t.Fatalf("ListProblemsFiltered: %v", err)
+		}
 		if len(results) != 3 {
 			t.Errorf("expected 3 problems, got %d", len(results))
 		}
@@ -331,7 +445,7 @@ func TestIntegration_ListProblemsFiltered(t *testing.T) {
 }
 
 // =============================================================================
-// Test: ListUsers
+// Test: ListUsers - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListUsers(t *testing.T) {
@@ -353,72 +467,44 @@ func TestIntegration_ListUsers(t *testing.T) {
 	db.createUser(ctx, t, u2, "instructor1@test.com", "instructor", nsA)
 	db.createUser(ctx, t, u3, "student2@test.com", "student", nsB)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	// Auth user in namespace A
+	authUser := &auth.User{
+		ID:          u1,
+		Email:       "student1@test.com",
+		NamespaceID: nsA,
+		Role:        auth.RoleStudent,
 	}
-	defer conn.Release()
 
-	runListUsers := func(t *testing.T, filters UserFilters) []User {
-		t.Helper()
-		query := `SELECT id, external_id, email, role, namespace_id, display_name, created_at, updated_at
-			FROM users WHERE 1=1`
-		var args []any
-		argIdx := 1
-		if filters.NamespaceID != nil {
-			query += fmt.Sprintf(" AND namespace_id = $%d", argIdx)
-			args = append(args, *filters.NamespaceID)
-			argIdx++
-		}
-		if filters.Role != nil {
-			query += fmt.Sprintf(" AND role = $%d", argIdx)
-			args = append(args, *filters.Role)
-		}
-		query += " ORDER BY created_at"
+	t.Run("user sees only own namespace users", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
 
-		rows, err := conn.Query(ctx, query, args...)
+		results, err := s.ListUsers(ctx, UserFilters{})
 		if err != nil {
-			t.Fatalf("query: %v", err)
+			t.Fatalf("ListUsers: %v", err)
 		}
-		defer rows.Close()
-		var users []User
-		for rows.Next() {
-			var u User
-			if err := rows.Scan(&u.ID, &u.ExternalID, &u.Email, &u.Role, &u.NamespaceID, &u.DisplayName, &u.CreatedAt, &u.UpdatedAt); err != nil {
-				t.Fatalf("scan: %v", err)
-			}
-			users = append(users, u)
-		}
-		return users
-	}
-
-	t.Run("no filters", func(t *testing.T) {
-		results := runListUsers(t, UserFilters{})
-		if len(results) != 3 {
-			t.Errorf("expected 3 users, got %d", len(results))
-		}
-	})
-
-	t.Run("filter by namespace", func(t *testing.T) {
-		ns := nsA
-		results := runListUsers(t, UserFilters{NamespaceID: &ns})
+		// Should see only users in namespace A (2 users: u1 and u2)
 		if len(results) != 2 {
 			t.Errorf("expected 2 users in nsA, got %d", len(results))
+		}
+		// Verify none of the results are from namespace B
+		for _, u := range results {
+			if u.NamespaceID != nil && *u.NamespaceID == nsB {
+				t.Errorf("user in namespace A should not see namespace B users")
+			}
 		}
 	})
 
 	t.Run("filter by role", func(t *testing.T) {
-		role := "student"
-		results := runListUsers(t, UserFilters{Role: &role})
-		if len(results) != 2 {
-			t.Errorf("expected 2 students, got %d", len(results))
-		}
-	})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
 
-	t.Run("filter by both", func(t *testing.T) {
-		ns := nsA
 		role := "student"
-		results := runListUsers(t, UserFilters{NamespaceID: &ns, Role: &role})
+		results, err := s.ListUsers(ctx, UserFilters{Role: &role})
+		if err != nil {
+			t.Fatalf("ListUsers: %v", err)
+		}
+		// In namespace A, there's only 1 student (u1)
 		if len(results) != 1 {
 			t.Errorf("expected 1 student in nsA, got %d", len(results))
 		}
@@ -429,7 +515,148 @@ func TestIntegration_ListUsers(t *testing.T) {
 }
 
 // =============================================================================
-// Test: DeleteMembershipIfNotLast
+// Test: Cross-namespace isolation - user in ns-A cannot see ns-B data
+// =============================================================================
+
+func TestIntegration_CrossNamespaceIsolation(t *testing.T) {
+	db := setupIntegrationDB(t)
+	defer db.close()
+	ctx := context.Background()
+
+	nsA := db.nsID
+	nsB := "ns-" + uuid.New().String()
+	db.createNamespace(ctx, t, nsB, "Namespace B")
+	t.Cleanup(func() {
+		_, _ = db.pool.Exec(ctx, "DELETE FROM namespaces WHERE id = $1", nsB)
+	})
+
+	// Create users in each namespace
+	userA := uuid.New()
+	userB := uuid.New()
+	db.createUser(ctx, t, userA, "userA@test.com", "instructor", nsA)
+	db.createUser(ctx, t, userB, "userB@test.com", "instructor", nsB)
+
+	// Create problems in each namespace
+	problemA := uuid.New()
+	problemB := uuid.New()
+	db.createProblem(ctx, t, problemA, nsA, "Problem in A", userA, nil, nil)
+	db.createProblem(ctx, t, problemB, nsB, "Problem in B", userB, nil, nil)
+
+	// Create classes in each namespace
+	classA := uuid.New()
+	classB := uuid.New()
+	db.createClass(ctx, t, classA, nsA, "Class in A", userA)
+	db.createClass(ctx, t, classB, nsB, "Class in B", userB)
+
+	// Auth user in namespace A
+	authUserA := &auth.User{
+		ID:          userA,
+		Email:       "userA@test.com",
+		NamespaceID: nsA,
+		Role:        auth.RoleInstructor,
+	}
+
+	t.Run("ListProblems does not return namespace B problems", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUserA)
+		defer conn.Release()
+
+		results, err := s.ListProblems(ctx, nil)
+		if err != nil {
+			t.Fatalf("ListProblems: %v", err)
+		}
+
+		for _, p := range results {
+			if p.ID == problemB {
+				t.Errorf("user in namespace A should not see problem from namespace B")
+			}
+			if p.NamespaceID == nsB {
+				t.Errorf("user in namespace A should not see any problems from namespace B")
+			}
+		}
+
+		// Should see the problem in namespace A
+		found := false
+		for _, p := range results {
+			if p.ID == problemA {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("user should see problem in their own namespace")
+		}
+	})
+
+	t.Run("ListClasses does not return namespace B classes", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUserA)
+		defer conn.Release()
+
+		results, err := s.ListClasses(ctx)
+		if err != nil {
+			t.Fatalf("ListClasses: %v", err)
+		}
+
+		for _, c := range results {
+			if c.ID == classB {
+				t.Errorf("user in namespace A should not see class from namespace B")
+			}
+			if c.NamespaceID == nsB {
+				t.Errorf("user in namespace A should not see any classes from namespace B")
+			}
+		}
+
+		found := false
+		for _, c := range results {
+			if c.ID == classA {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("user should see class in their own namespace")
+		}
+	})
+
+	t.Run("GetProblem returns not found for namespace B problem", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUserA)
+		defer conn.Release()
+
+		_, err := s.GetProblem(ctx, problemB)
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound when accessing namespace B problem, got: %v", err)
+		}
+	})
+
+	t.Run("GetClass returns not found for namespace B class", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUserA)
+		defer conn.Release()
+
+		_, err := s.GetClass(ctx, classB)
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("expected ErrNotFound when accessing namespace B class, got: %v", err)
+		}
+	})
+
+	t.Run("ListNamespaces only shows own namespace", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUserA)
+		defer conn.Release()
+
+		results, err := s.ListNamespaces(ctx)
+		if err != nil {
+			t.Fatalf("ListNamespaces: %v", err)
+		}
+
+		if len(results) != 1 {
+			t.Errorf("expected 1 namespace, got %d", len(results))
+		}
+		if len(results) > 0 && results[0].ID != nsA {
+			t.Errorf("expected namespace %s, got %s", nsA, results[0].ID)
+		}
+	})
+}
+
+// =============================================================================
+// Test: DeleteMembershipIfNotLast - calls actual Store method
 // =============================================================================
 
 func TestIntegration_DeleteMembershipIfNotLast(t *testing.T) {
@@ -454,60 +681,24 @@ func TestIntegration_DeleteMembershipIfNotLast(t *testing.T) {
 	db.createMembership(ctx, t, instructor2, sectionID, "instructor")
 	db.createMembership(ctx, t, student1, sectionID, "student")
 
-	// deleteMembershipIfNotLast tests the transactional delete-if-not-last logic.
-	// Note: The production code uses "SELECT COUNT(*) ... FOR UPDATE" which fails on
-	// PostgreSQL 15+ (FOR UPDATE not allowed with aggregates). This test uses a
-	// compatible approach that validates the same business logic: lock rows first,
-	// then count, then conditionally delete.
-	deleteMembershipIfNotLast := func(ctx context.Context, pool *pgxpool.Pool, sectionID, userID uuid.UUID, role string) error {
-		tx, err := pool.Begin(ctx)
-		if err != nil {
-			return err
-		}
-		defer tx.Rollback(ctx) //nolint:errcheck
-
-		// Lock rows, then count (compatible with PG 15+)
-		rows, err := tx.Query(ctx,
-			`SELECT id FROM section_memberships WHERE section_id = $1 AND role = $2 FOR UPDATE`,
-			sectionID, role)
-		if err != nil {
-			return err
-		}
-		count := 0
-		for rows.Next() {
-			var id uuid.UUID
-			if err := rows.Scan(&id); err != nil {
-				rows.Close()
-				return err
-			}
-			count++
-		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			return err
-		}
-
-		if count <= 1 {
-			return ErrLastMember
-		}
-		tag, err := tx.Exec(ctx,
-			`DELETE FROM section_memberships WHERE section_id = $1 AND user_id = $2 AND role = $3`,
-			sectionID, userID, role)
-		if err != nil {
-			return err
-		}
-		if tag.RowsAffected() == 0 {
-			return ErrNotFound
-		}
-		return tx.Commit(ctx)
+	// Auth user for RLS context
+	authUser := &auth.User{
+		ID:          instructor1,
+		Email:       "inst1@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("can remove one of two instructors", func(t *testing.T) {
-		err := deleteMembershipIfNotLast(ctx, db.pool, sectionID, instructor2, "instructor")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		err := s.DeleteMembershipIfNotLast(ctx, sectionID, instructor2, "instructor")
 		if err != nil {
 			t.Fatalf("expected success, got: %v", err)
 		}
-		// Verify deleted
+
+		// Verify deleted using superuser connection
 		var count int
 		err = db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM section_memberships WHERE section_id = $1 AND user_id = $2",
 			sectionID, instructor2).Scan(&count)
@@ -520,14 +711,20 @@ func TestIntegration_DeleteMembershipIfNotLast(t *testing.T) {
 	})
 
 	t.Run("cannot remove last instructor", func(t *testing.T) {
-		err := deleteMembershipIfNotLast(ctx, db.pool, sectionID, instructor1, "instructor")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		err := s.DeleteMembershipIfNotLast(ctx, sectionID, instructor1, "instructor")
 		if !errors.Is(err, ErrLastMember) {
 			t.Errorf("expected ErrLastMember, got: %v", err)
 		}
 	})
 
 	t.Run("cannot remove last student", func(t *testing.T) {
-		err := deleteMembershipIfNotLast(ctx, db.pool, sectionID, student1, "student")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		err := s.DeleteMembershipIfNotLast(ctx, sectionID, student1, "student")
 		if !errors.Is(err, ErrLastMember) {
 			t.Errorf("expected ErrLastMember, got: %v", err)
 		}
@@ -539,9 +736,12 @@ func TestIntegration_DeleteMembershipIfNotLast(t *testing.T) {
 		db.createUser(ctx, t, student2, "stu2@test.com", "student", nsID)
 		db.createMembership(ctx, t, student2, sectionID, "student")
 
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		nonexistent := uuid.New()
 		db.createUser(ctx, t, nonexistent, "ghost@test.com", "student", nsID)
-		err := deleteMembershipIfNotLast(ctx, db.pool, sectionID, nonexistent, "student")
+		err := s.DeleteMembershipIfNotLast(ctx, sectionID, nonexistent, "student")
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -549,7 +749,7 @@ func TestIntegration_DeleteMembershipIfNotLast(t *testing.T) {
 }
 
 // =============================================================================
-// Test: GetUserByEmail
+// Test: GetUserByEmail - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_GetUserByEmail(t *testing.T) {
@@ -562,26 +762,18 @@ func TestIntegration_GetUserByEmail(t *testing.T) {
 	testEmail := fmt.Sprintf("findme-%s@test.com", nsID)
 	db.createUser(ctx, t, userID, testEmail, "student", nsID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getUserByEmail := func(email string) (*User, error) {
-		var u User
-		err := conn.QueryRow(ctx,
-			`SELECT id, external_id, email, role, namespace_id, display_name, created_at, updated_at
-			 FROM users WHERE email = $1`, email).Scan(
-			&u.ID, &u.ExternalID, &u.Email, &u.Role, &u.NamespaceID, &u.DisplayName, &u.CreatedAt, &u.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &u, nil
+	authUser := &auth.User{
+		ID:          userID,
+		Email:       testEmail,
+		NamespaceID: nsID,
+		Role:        auth.RoleStudent,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		u, err := getUserByEmail(testEmail)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		u, err := s.GetUserByEmail(ctx, testEmail)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -594,7 +786,10 @@ func TestIntegration_GetUserByEmail(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getUserByEmail("nonexistent-" + nsID + "@test.com")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetUserByEmail(ctx, "nonexistent-"+nsID+"@test.com")
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -602,7 +797,7 @@ func TestIntegration_GetUserByEmail(t *testing.T) {
 }
 
 // =============================================================================
-// Test: UpdateUserAdmin
+// Test: UpdateUserAdmin - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_UpdateUserAdmin(t *testing.T) {
@@ -614,34 +809,31 @@ func TestIntegration_UpdateUserAdmin(t *testing.T) {
 	userID := uuid.New()
 	db.createUser(ctx, t, userID, "admin-target@test.com", "student", nsID)
 
-	conn, err := db.pool.Acquire(ctx)
+	// RLS policy: only system-admin can update other users
+	adminID := uuid.New()
+	err := db.execAsSuperuser(ctx,
+		`INSERT INTO users (id, email, role) VALUES ($1, $2, $3)`,
+		adminID, "sysadmin@test.com", "system-admin")
 	if err != nil {
-		t.Fatalf("acquire: %v", err)
+		t.Fatalf("create admin: %v", err)
 	}
-	defer conn.Release()
+	t.Cleanup(func() {
+		_, _ = db.pool.Exec(ctx, "DELETE FROM users WHERE id = $1", adminID)
+	})
 
-	updateUserAdmin := func(id uuid.UUID, params UpdateUserAdminParams) (*User, error) {
-		var u User
-		err := conn.QueryRow(ctx,
-			`UPDATE users
-			 SET email        = COALESCE($2, email),
-			     display_name = COALESCE($3, display_name),
-			     role         = COALESCE($4, role),
-			     namespace_id = COALESCE($5, namespace_id),
-			     updated_at   = now()
-			 WHERE id = $1
-			 RETURNING id, external_id, email, role, namespace_id, display_name, created_at, updated_at`,
-			id, params.Email, params.DisplayName, params.Role, params.NamespaceID).Scan(
-			&u.ID, &u.ExternalID, &u.Email, &u.Role, &u.NamespaceID, &u.DisplayName, &u.CreatedAt, &u.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &u, nil
+	authUser := &auth.User{
+		ID:          adminID,
+		Email:       "sysadmin@test.com",
+		NamespaceID: "",
+		Role:        auth.RoleSystemAdmin,
 	}
 
 	t.Run("partial update email only", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newEmail := "updated@test.com"
-		u, err := updateUserAdmin(userID, UpdateUserAdminParams{Email: &newEmail})
+		u, err := s.UpdateUserAdmin(ctx, userID, UpdateUserAdminParams{Email: &newEmail})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -654,8 +846,11 @@ func TestIntegration_UpdateUserAdmin(t *testing.T) {
 	})
 
 	t.Run("partial update role only", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newRole := "instructor"
-		u, err := updateUserAdmin(userID, UpdateUserAdminParams{Role: &newRole})
+		u, err := s.UpdateUserAdmin(ctx, userID, UpdateUserAdminParams{Role: &newRole})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -668,10 +863,13 @@ func TestIntegration_UpdateUserAdmin(t *testing.T) {
 	})
 
 	t.Run("update all fields", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		email := "fully-updated@test.com"
 		display := "Full Update"
 		role := "namespace-admin"
-		u, err := updateUserAdmin(userID, UpdateUserAdminParams{
+		u, err := s.UpdateUserAdmin(ctx, userID, UpdateUserAdminParams{
 			Email: &email, DisplayName: &display, Role: &role, NamespaceID: &nsID,
 		})
 		if err != nil {
@@ -686,8 +884,11 @@ func TestIntegration_UpdateUserAdmin(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		email := "nope@test.com"
-		_, err := updateUserAdmin(uuid.New(), UpdateUserAdminParams{Email: &email})
+		_, err := s.UpdateUserAdmin(ctx, uuid.New(), UpdateUserAdminParams{Email: &email})
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -695,7 +896,7 @@ func TestIntegration_UpdateUserAdmin(t *testing.T) {
 }
 
 // =============================================================================
-// Test: DeleteUser
+// Test: DeleteUser - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_DeleteUser(t *testing.T) {
@@ -707,29 +908,36 @@ func TestIntegration_DeleteUser(t *testing.T) {
 	userID := uuid.New()
 	db.createUser(ctx, t, userID, "todelete@test.com", "student", nsID)
 
-	conn, err := db.pool.Acquire(ctx)
+	// RLS policy: only system-admin can delete users
+	adminID := uuid.New()
+	err := db.execAsSuperuser(ctx,
+		`INSERT INTO users (id, email, role) VALUES ($1, $2, $3)`,
+		adminID, "sysadmin-del@test.com", "system-admin")
 	if err != nil {
-		t.Fatalf("acquire: %v", err)
+		t.Fatalf("create admin: %v", err)
 	}
-	defer conn.Release()
+	t.Cleanup(func() {
+		_, _ = db.pool.Exec(ctx, "DELETE FROM users WHERE id = $1", adminID)
+	})
 
-	deleteUser := func(id uuid.UUID) error {
-		tag, err := conn.Exec(ctx, "DELETE FROM users WHERE id = $1", id)
-		if err != nil {
-			return err
-		}
-		if tag.RowsAffected() == 0 {
-			return ErrNotFound
-		}
-		return nil
+	authUser := &auth.User{
+		ID:          adminID,
+		Email:       "sysadmin-del@test.com",
+		NamespaceID: "",
+		Role:        auth.RoleSystemAdmin,
 	}
 
 	t.Run("delete existing user", func(t *testing.T) {
-		if err := deleteUser(userID); err != nil {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		if err := s.DeleteUser(ctx, userID); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+
+		// Verify using superuser connection
 		var count int
-		err = db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM users WHERE id = $1", userID).Scan(&count)
+		err := db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM users WHERE id = $1", userID).Scan(&count)
 		if err != nil {
 			t.Fatalf("count query: %v", err)
 		}
@@ -739,7 +947,10 @@ func TestIntegration_DeleteUser(t *testing.T) {
 	})
 
 	t.Run("delete nonexistent user", func(t *testing.T) {
-		err := deleteUser(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		err := s.DeleteUser(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -747,7 +958,7 @@ func TestIntegration_DeleteUser(t *testing.T) {
 }
 
 // =============================================================================
-// Test: CountUsersByRole
+// Test: CountUsersByRole - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_CountUsersByRole(t *testing.T) {
@@ -756,37 +967,25 @@ func TestIntegration_CountUsersByRole(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	db.createUser(ctx, t, uuid.New(), "s1@test.com", "student", nsID)
-	db.createUser(ctx, t, uuid.New(), "s2@test.com", "student", nsID)
-	db.createUser(ctx, t, uuid.New(), "i1@test.com", "instructor", nsID)
+	u1 := uuid.New()
+	u2 := uuid.New()
+	u3 := uuid.New()
+	db.createUser(ctx, t, u1, "s1@test.com", "student", nsID)
+	db.createUser(ctx, t, u2, "s2@test.com", "student", nsID)
+	db.createUser(ctx, t, u3, "i1@test.com", "instructor", nsID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	countUsersByRole := func(namespaceID string) (map[string]int, error) {
-		rows, err := conn.Query(ctx,
-			`SELECT role, COUNT(*) FROM users WHERE namespace_id = $1 GROUP BY role`, namespaceID)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		counts := make(map[string]int)
-		for rows.Next() {
-			var role string
-			var count int
-			if err := rows.Scan(&role, &count); err != nil {
-				return nil, err
-			}
-			counts[role] = count
-		}
-		return counts, rows.Err()
+	authUser := &auth.User{
+		ID:          u3,
+		Email:       "i1@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("counts are correct", func(t *testing.T) {
-		counts, err := countUsersByRole(nsID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		counts, err := s.CountUsersByRole(ctx, nsID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -804,7 +1003,11 @@ func TestIntegration_CountUsersByRole(t *testing.T) {
 		t.Cleanup(func() {
 			_, _ = db.pool.Exec(ctx, "DELETE FROM namespaces WHERE id = $1", emptyNS)
 		})
-		counts, err := countUsersByRole(emptyNS)
+
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		counts, err := s.CountUsersByRole(ctx, emptyNS)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -815,7 +1018,7 @@ func TestIntegration_CountUsersByRole(t *testing.T) {
 }
 
 // =============================================================================
-// Test: ListClassInstructorNames
+// Test: ListClassInstructorNames - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListClassInstructorNames(t *testing.T) {
@@ -843,37 +1046,18 @@ func TestIntegration_ListClassInstructorNames(t *testing.T) {
 	db.createMembership(ctx, t, inst1, sec2, "instructor") // inst1 in both sections
 	db.createMembership(ctx, t, student, sec1, "student")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listClassInstructorNames := func(classID uuid.UUID) ([]string, error) {
-		rows, err := conn.Query(ctx, `
-			SELECT DISTINCT COALESCE(u.display_name, u.email)
-			FROM sections s
-			JOIN section_memberships sm ON sm.section_id = s.id
-			JOIN users u ON u.id = sm.user_id
-			WHERE s.class_id = $1 AND sm.role = 'instructor'
-			ORDER BY 1`, classID)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		var names []string
-		for rows.Next() {
-			var name string
-			if err := rows.Scan(&name); err != nil {
-				return nil, err
-			}
-			names = append(names, name)
-		}
-		return names, rows.Err()
+	authUser := &auth.User{
+		ID:          inst1,
+		Email:       "inst1@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("returns distinct instructor names", func(t *testing.T) {
-		names, err := listClassInstructorNames(classID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		names, err := s.ListClassInstructorNames(ctx, classID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -890,7 +1074,10 @@ func TestIntegration_ListClassInstructorNames(t *testing.T) {
 	})
 
 	t.Run("empty class", func(t *testing.T) {
-		names, err := listClassInstructorNames(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		names, err := s.ListClassInstructorNames(ctx, uuid.New())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -901,7 +1088,7 @@ func TestIntegration_ListClassInstructorNames(t *testing.T) {
 }
 
 // =============================================================================
-// Test: ListMySections
+// Test: ListMySections - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListMySections(t *testing.T) {
@@ -931,43 +1118,18 @@ func TestIntegration_ListMySections(t *testing.T) {
 	db.createMembership(ctx, t, userID, sec2, "student")
 	db.createMembership(ctx, t, otherUser, sec3, "student") // other user, not me
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listMySections := func(uid uuid.UUID) ([]MySectionInfo, error) {
-		rows, err := conn.Query(ctx, `
-			SELECT s.id, s.namespace_id, s.class_id, s.name, s.semester, s.join_code, s.active,
-			       s.created_at, s.updated_at, c.name
-			FROM sections s
-			JOIN section_memberships sm ON sm.section_id = s.id
-			JOIN classes c ON c.id = s.class_id
-			WHERE sm.user_id = $1
-			ORDER BY s.created_at`, uid)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		var results []MySectionInfo
-		for rows.Next() {
-			var info MySectionInfo
-			if err := rows.Scan(
-				&info.Section.ID, &info.Section.NamespaceID, &info.Section.ClassID,
-				&info.Section.Name, &info.Section.Semester, &info.Section.JoinCode,
-				&info.Section.Active, &info.Section.CreatedAt, &info.Section.UpdatedAt,
-				&info.ClassName,
-			); err != nil {
-				return nil, err
-			}
-			results = append(results, info)
-		}
-		return results, rows.Err()
+	authUser := &auth.User{
+		ID:          userID,
+		Email:       "me@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleStudent,
 	}
 
 	t.Run("returns my sections with class names", func(t *testing.T) {
-		results, err := listMySections(userID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListMySections(ctx, userID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -983,7 +1145,10 @@ func TestIntegration_ListMySections(t *testing.T) {
 	})
 
 	t.Run("user with no sections", func(t *testing.T) {
-		results, err := listMySections(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListMySections(ctx, uuid.New())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -994,7 +1159,7 @@ func TestIntegration_ListMySections(t *testing.T) {
 }
 
 // =============================================================================
-// Test: UpdateSectionJoinCode
+// Test: UpdateSectionJoinCode - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_UpdateSectionJoinCode(t *testing.T) {
@@ -1009,35 +1174,27 @@ func TestIntegration_UpdateSectionJoinCode(t *testing.T) {
 	db.createClass(ctx, t, classID, nsID, "CS101", instructorID)
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "OLD_CODE")
+	// RLS requires instructor to be a section instructor to update sections
+	db.createMembership(ctx, t, instructorID, sectionID, "instructor")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	updateJoinCode := func(id uuid.UUID, code string) (*Section, error) {
-		var sec Section
-		err := conn.QueryRow(ctx, `
-			UPDATE sections SET join_code = $2, updated_at = now()
-			WHERE id = $1
-			RETURNING id, namespace_id, class_id, name, semester, join_code, active, created_at, updated_at`,
-			id, code).Scan(
-			&sec.ID, &sec.NamespaceID, &sec.ClassID, &sec.Name, &sec.Semester,
-			&sec.JoinCode, &sec.Active, &sec.CreatedAt, &sec.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &sec, nil
+	authUser := &auth.User{
+		ID:          instructorID,
+		Email:       "inst@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("updates join code", func(t *testing.T) {
-		sec, err := updateJoinCode(sectionID, "NEW_CODE")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		newCode := "NEW_CODE-" + uuid.New().String()[:8]
+		sec, err := s.UpdateSectionJoinCode(ctx, sectionID, newCode)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if sec.JoinCode != "NEW_CODE" {
-			t.Errorf("expected join_code NEW_CODE, got %s", sec.JoinCode)
+		if sec.JoinCode != newCode {
+			t.Errorf("expected join_code %s, got %s", newCode, sec.JoinCode)
 		}
 		if sec.ID != sectionID {
 			t.Errorf("expected section %s, got %s", sectionID, sec.ID)
@@ -1045,7 +1202,10 @@ func TestIntegration_UpdateSectionJoinCode(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := updateJoinCode(uuid.New(), "WHATEVER")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.UpdateSectionJoinCode(ctx, uuid.New(), "WHATEVER-"+uuid.New().String()[:8])
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -1053,7 +1213,7 @@ func TestIntegration_UpdateSectionJoinCode(t *testing.T) {
 }
 
 // =============================================================================
-// Test: ListMembersByRole
+// Test: ListMembersByRole - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListMembersByRole(t *testing.T) {
@@ -1079,35 +1239,18 @@ func TestIntegration_ListMembersByRole(t *testing.T) {
 	db.createMembership(ctx, t, stu1, secID, "student")
 	db.createMembership(ctx, t, stu2, secID, "student")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listMembersByRole := func(sectionID uuid.UUID, role string) ([]SectionMembership, error) {
-		rows, err := conn.Query(ctx, `
-			SELECT id, user_id, section_id, role, joined_at
-			FROM section_memberships
-			WHERE section_id = $1 AND role = $2
-			ORDER BY joined_at`, sectionID, role)
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
-		var members []SectionMembership
-		for rows.Next() {
-			var m SectionMembership
-			if err := rows.Scan(&m.ID, &m.UserID, &m.SectionID, &m.Role, &m.JoinedAt); err != nil {
-				return nil, err
-			}
-			members = append(members, m)
-		}
-		return members, rows.Err()
+	authUser := &auth.User{
+		ID:          inst,
+		Email:       "inst@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("students only", func(t *testing.T) {
-		members, err := listMembersByRole(secID, "student")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		members, err := s.ListMembersByRole(ctx, secID, "student")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1122,7 +1265,10 @@ func TestIntegration_ListMembersByRole(t *testing.T) {
 	})
 
 	t.Run("instructors only", func(t *testing.T) {
-		members, err := listMembersByRole(secID, "instructor")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		members, err := s.ListMembersByRole(ctx, secID, "instructor")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1132,7 +1278,10 @@ func TestIntegration_ListMembersByRole(t *testing.T) {
 	})
 
 	t.Run("empty section", func(t *testing.T) {
-		members, err := listMembersByRole(uuid.New(), "student")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		members, err := s.ListMembersByRole(ctx, uuid.New(), "student")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1143,7 +1292,7 @@ func TestIntegration_ListMembersByRole(t *testing.T) {
 }
 
 // =============================================================================
-// UpsertUser Tests
+// UpsertUser Tests - calls actual Store method (superuser, no RLS needed)
 // =============================================================================
 
 func TestIntegration_UpsertUser_Insert(t *testing.T) {

--- a/go-backend/internal/store/store_session_integration_test.go
+++ b/go-backend/internal/store/store_session_integration_test.go
@@ -1,5 +1,9 @@
 // Integration tests for sessions, session students, revisions, problems CRUD, and users.
 //
+// These tests validate actual Store methods with proper RLS context,
+// ensuring that the SQL queries, scanning logic, and RLS policies work
+// together as they would in production.
+//
 // Run with:
 //
 //	DATABASE_URL="postgres://eval:eval_local_password@localhost:5432/eval?sslmode=disable" go test ./internal/store/... -run TestIntegration
@@ -9,18 +13,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jdelfino/eval/internal/auth"
 )
 
 // seed helpers for sessions
 
 func (db *integrationDB) createSession(ctx context.Context, t *testing.T, id uuid.UUID, nsID string, sectionID uuid.UUID, sectionName string, creatorID uuid.UUID) {
 	t.Helper()
-	_, err := db.pool.Exec(ctx,
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO sessions (id, namespace_id, section_id, section_name, problem, creator_id) VALUES ($1, $2, $3, $4, '{}', $5)`,
 		id, nsID, sectionID, sectionName, creatorID)
 	if err != nil {
@@ -30,7 +34,7 @@ func (db *integrationDB) createSession(ctx context.Context, t *testing.T, id uui
 
 func (db *integrationDB) createSessionStudent(ctx context.Context, t *testing.T, sessionID, userID uuid.UUID, name string) {
 	t.Helper()
-	_, err := db.pool.Exec(ctx,
+	err := db.execAsSuperuser(ctx,
 		`INSERT INTO session_students (session_id, user_id, name) VALUES ($1, $2, $3)`,
 		sessionID, userID, name)
 	if err != nil {
@@ -39,7 +43,7 @@ func (db *integrationDB) createSessionStudent(ctx context.Context, t *testing.T,
 }
 
 // =============================================================================
-// Test: CreateSession
+// Test: CreateSession - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_CreateSession(t *testing.T) {
@@ -48,7 +52,6 @@ func TestIntegration_CreateSession(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-create-session"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -57,25 +60,25 @@ func TestIntegration_CreateSession(t *testing.T) {
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN1")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	authUser := &auth.User{
+		ID:          creatorID,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
-	defer conn.Release()
 
 	t.Run("successful creation with defaults", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		problem := json.RawMessage(`{"title":"Two Sum"}`)
-		var sess Session
-		err := conn.QueryRow(ctx,
-			`INSERT INTO sessions (namespace_id, section_id, section_name, problem, creator_id)
-			 VALUES ($1, $2, $3, $4, $5)
-			 RETURNING id, namespace_id, section_id, section_name, problem,
-			           featured_student_id, featured_code, creator_id, participants,
-			           status, created_at, last_activity, ended_at`,
-			nsID, sectionID, "Section A", problem, creatorID,
-		).Scan(&sess.ID, &sess.NamespaceID, &sess.SectionID, &sess.SectionName, &sess.Problem,
-			&sess.FeaturedStudentID, &sess.FeaturedCode, &sess.CreatorID, &sess.Participants,
-			&sess.Status, &sess.CreatedAt, &sess.LastActivity, &sess.EndedAt)
+		sess, err := s.CreateSession(ctx, CreateSessionParams{
+			NamespaceID: nsID,
+			SectionID:   sectionID,
+			SectionName: "Section A",
+			Problem:     problem,
+			CreatorID:   creatorID,
+		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -107,7 +110,7 @@ func TestIntegration_CreateSession(t *testing.T) {
 }
 
 // =============================================================================
-// Test: GetSession
+// Test: GetSession - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_GetSession(t *testing.T) {
@@ -116,7 +119,6 @@ func TestIntegration_GetSession(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-get-session"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -127,30 +129,18 @@ func TestIntegration_GetSession(t *testing.T) {
 	sessionID := uuid.New()
 	db.createSession(ctx, t, sessionID, nsID, sectionID, "Section A", creatorID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getSession := func(id uuid.UUID) (*Session, error) {
-		var sess Session
-		err := conn.QueryRow(ctx,
-			`SELECT id, namespace_id, section_id, section_name, problem,
-			        featured_student_id, featured_code, creator_id, participants,
-			        status, created_at, last_activity, ended_at
-			 FROM sessions WHERE id = $1`, id).Scan(
-			&sess.ID, &sess.NamespaceID, &sess.SectionID, &sess.SectionName, &sess.Problem,
-			&sess.FeaturedStudentID, &sess.FeaturedCode, &sess.CreatorID, &sess.Participants,
-			&sess.Status, &sess.CreatedAt, &sess.LastActivity, &sess.EndedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &sess, nil
+	authUser := &auth.User{
+		ID:          creatorID,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		sess, err := getSession(sessionID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		sess, err := s.GetSession(ctx, sessionID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -163,7 +153,10 @@ func TestIntegration_GetSession(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getSession(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetSession(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -171,7 +164,7 @@ func TestIntegration_GetSession(t *testing.T) {
 }
 
 // =============================================================================
-// Test: ListSessions
+// Test: ListSessions - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListSessions(t *testing.T) {
@@ -180,7 +173,6 @@ func TestIntegration_ListSessions(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-list-sessions"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -206,51 +198,21 @@ func TestIntegration_ListSessions(t *testing.T) {
 		t.Fatalf("update session status: %v", err)
 	}
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listSessions := func(filters SessionFilters) []Session {
-		t.Helper()
-		query := `SELECT id, namespace_id, section_id, section_name, problem,
-		                 featured_student_id, featured_code, creator_id, participants,
-		                 status, created_at, last_activity, ended_at
-		          FROM sessions WHERE 1=1`
-		var args []any
-		argIdx := 1
-		if filters.SectionID != nil {
-			query += fmt.Sprintf(" AND section_id = $%d", argIdx)
-			args = append(args, *filters.SectionID)
-			argIdx++
-		}
-		if filters.Status != nil {
-			query += fmt.Sprintf(" AND status = $%d", argIdx)
-			args = append(args, *filters.Status)
-		}
-		query += " ORDER BY created_at DESC"
-
-		rows, err := conn.Query(ctx, query, args...)
-		if err != nil {
-			t.Fatalf("query: %v", err)
-		}
-		defer rows.Close()
-		var sessions []Session
-		for rows.Next() {
-			var s Session
-			if err := rows.Scan(&s.ID, &s.NamespaceID, &s.SectionID, &s.SectionName, &s.Problem,
-				&s.FeaturedStudentID, &s.FeaturedCode, &s.CreatorID, &s.Participants,
-				&s.Status, &s.CreatedAt, &s.LastActivity, &s.EndedAt); err != nil {
-				t.Fatalf("scan: %v", err)
-			}
-			sessions = append(sessions, s)
-		}
-		return sessions
+	authUser := &auth.User{
+		ID:          creatorID,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("no filters returns all desc", func(t *testing.T) {
-		results := listSessions(SessionFilters{})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListSessions(ctx, SessionFilters{})
+		if err != nil {
+			t.Fatalf("ListSessions: %v", err)
+		}
 		if len(results) != 3 {
 			t.Fatalf("expected 3 sessions, got %d", len(results))
 		}
@@ -261,15 +223,27 @@ func TestIntegration_ListSessions(t *testing.T) {
 	})
 
 	t.Run("filter by section_id", func(t *testing.T) {
-		results := listSessions(SessionFilters{SectionID: &sec1})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListSessions(ctx, SessionFilters{SectionID: &sec1})
+		if err != nil {
+			t.Fatalf("ListSessions: %v", err)
+		}
 		if len(results) != 2 {
 			t.Errorf("expected 2 sessions in section A, got %d", len(results))
 		}
 	})
 
 	t.Run("filter by status", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		status := "active"
-		results := listSessions(SessionFilters{Status: &status})
+		results, err := s.ListSessions(ctx, SessionFilters{Status: &status})
+		if err != nil {
+			t.Fatalf("ListSessions: %v", err)
+		}
 		if len(results) != 2 {
 			t.Errorf("expected 2 active sessions, got %d", len(results))
 		}
@@ -277,7 +251,7 @@ func TestIntegration_ListSessions(t *testing.T) {
 }
 
 // =============================================================================
-// Test: UpdateSession
+// Test: UpdateSession - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_UpdateSession(t *testing.T) {
@@ -286,7 +260,6 @@ func TestIntegration_UpdateSession(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-update-session"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -299,62 +272,19 @@ func TestIntegration_UpdateSession(t *testing.T) {
 	sessionID := uuid.New()
 	db.createSession(ctx, t, sessionID, nsID, sectionID, "Section A", creatorID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	updateSession := func(id uuid.UUID, params UpdateSessionParams) (*Session, error) {
-		query := `UPDATE sessions SET last_activity = now()`
-		args := []any{id}
-		argIdx := 2
-
-		if params.FeaturedStudentID != nil {
-			query += fmt.Sprintf(", featured_student_id = $%d", argIdx)
-			args = append(args, *params.FeaturedStudentID)
-			argIdx++
-		}
-		if params.FeaturedCode != nil {
-			query += fmt.Sprintf(", featured_code = $%d", argIdx)
-			args = append(args, *params.FeaturedCode)
-			argIdx++
-		}
-		if params.Status != nil {
-			query += fmt.Sprintf(", status = $%d", argIdx)
-			args = append(args, *params.Status)
-			argIdx++
-		}
-		if params.EndedAt != nil {
-			query += fmt.Sprintf(", ended_at = $%d", argIdx)
-			args = append(args, *params.EndedAt)
-			argIdx++ //nolint:ineffassign // keep argIdx consistent for future fields
-		}
-		if params.ClearEndedAt {
-			query += ", ended_at = NULL"
-		}
-		if params.ClearFeatured {
-			query += ", featured_student_id = NULL, featured_code = NULL"
-		}
-		query += ` WHERE id = $1
-		RETURNING id, namespace_id, section_id, section_name, problem,
-		          featured_student_id, featured_code, creator_id, participants,
-		          status, created_at, last_activity, ended_at`
-
-		var sess Session
-		err := conn.QueryRow(ctx, query, args...).Scan(
-			&sess.ID, &sess.NamespaceID, &sess.SectionID, &sess.SectionName, &sess.Problem,
-			&sess.FeaturedStudentID, &sess.FeaturedCode, &sess.CreatorID, &sess.Participants,
-			&sess.Status, &sess.CreatedAt, &sess.LastActivity, &sess.EndedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &sess, nil
+	authUser := &auth.User{
+		ID:          creatorID,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("update featured student", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		code := "print('hello')"
-		sess, err := updateSession(sessionID, UpdateSessionParams{
+		sess, err := s.UpdateSession(ctx, sessionID, UpdateSessionParams{
 			FeaturedStudentID: &studentID,
 			FeaturedCode:      &code,
 		})
@@ -370,7 +300,10 @@ func TestIntegration_UpdateSession(t *testing.T) {
 	})
 
 	t.Run("clear featured", func(t *testing.T) {
-		sess, err := updateSession(sessionID, UpdateSessionParams{ClearFeatured: true})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		sess, err := s.UpdateSession(ctx, sessionID, UpdateSessionParams{ClearFeatured: true})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -383,9 +316,12 @@ func TestIntegration_UpdateSession(t *testing.T) {
 	})
 
 	t.Run("update status and ended_at", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		status := "completed"
 		now := time.Now()
-		sess, err := updateSession(sessionID, UpdateSessionParams{
+		sess, err := s.UpdateSession(ctx, sessionID, UpdateSessionParams{
 			Status:  &status,
 			EndedAt: &now,
 		})
@@ -401,7 +337,10 @@ func TestIntegration_UpdateSession(t *testing.T) {
 	})
 
 	t.Run("clear ended_at", func(t *testing.T) {
-		sess, err := updateSession(sessionID, UpdateSessionParams{ClearEndedAt: true})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		sess, err := s.UpdateSession(ctx, sessionID, UpdateSessionParams{ClearEndedAt: true})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -411,8 +350,11 @@ func TestIntegration_UpdateSession(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		status := "completed"
-		_, err := updateSession(uuid.New(), UpdateSessionParams{Status: &status})
+		_, err := s.UpdateSession(ctx, uuid.New(), UpdateSessionParams{Status: &status})
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -420,7 +362,7 @@ func TestIntegration_UpdateSession(t *testing.T) {
 }
 
 // =============================================================================
-// Test: JoinSession
+// Test: JoinSession - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_JoinSession(t *testing.T) {
@@ -429,7 +371,6 @@ func TestIntegration_JoinSession(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-join-session"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -439,51 +380,33 @@ func TestIntegration_JoinSession(t *testing.T) {
 	db.createClass(ctx, t, classID, nsID, "CS101", creatorID)
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN1")
+	// Student needs to be section member to see/join session
+	db.createMembership(ctx, t, studentID, sectionID, "student")
+	// Instructor needs section membership to update sessions
+	db.createMembership(ctx, t, creatorID, sectionID, "instructor")
 	sessionID := uuid.New()
 	db.createSession(ctx, t, sessionID, nsID, sectionID, "Section A", creatorID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	// JoinSession uses a transaction (INSERT + UPDATE participants), so we replicate both statements.
-	joinSession := func(params JoinSessionParams) (*SessionStudent, error) {
-		tx, err := db.pool.Begin(ctx)
-		if err != nil {
-			return nil, err
-		}
-		defer tx.Rollback(ctx) //nolint:errcheck
-
-		var ss SessionStudent
-		err = tx.QueryRow(ctx,
-			`INSERT INTO session_students (session_id, user_id, name)
-			 VALUES ($1, $2, $3)
-			 ON CONFLICT (session_id, user_id) DO UPDATE SET name = EXCLUDED.name
-			 RETURNING id, session_id, user_id, name, code, execution_settings, last_update`,
-			params.SessionID, params.UserID, params.Name,
-		).Scan(&ss.ID, &ss.SessionID, &ss.UserID, &ss.Name, &ss.Code, &ss.ExecutionSettings, &ss.LastUpdate)
-		if err != nil {
-			return nil, err
-		}
-
-		_, err = tx.Exec(ctx,
-			`UPDATE sessions SET participants = array_append(participants, $2)
-			 WHERE id = $1 AND NOT ($2 = ANY(participants))`,
-			params.SessionID, params.UserID)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := tx.Commit(ctx); err != nil {
-			return nil, err
-		}
-		return &ss, nil
+	// Use system-admin as auth user.
+	// JoinSession inserts into session_students (requires user_id = app_user_id() OR is_system_admin())
+	// and updates sessions.participants (requires creator/instructor/system-admin).
+	// A student can insert their own record but can't update sessions.
+	// An instructor can update sessions but can't insert session_students for others.
+	// Only system-admin can do both.
+	systemAdminID := uuid.New()
+	db.createUser(ctx, t, systemAdminID, "sysadmin@test.com", "system-admin", "")
+	authUser := &auth.User{
+		ID:          systemAdminID,
+		Email:       "sysadmin@test.com",
+		NamespaceID: "", // system-admin doesn't belong to a namespace
+		Role:        auth.RoleSystemAdmin,
 	}
 
 	t.Run("first join", func(t *testing.T) {
-		ss, err := joinSession(JoinSessionParams{SessionID: sessionID, UserID: studentID, Name: "Alice"})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		ss, err := s.JoinSession(ctx, JoinSessionParams{SessionID: sessionID, UserID: studentID, Name: "Alice"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -518,7 +441,10 @@ func TestIntegration_JoinSession(t *testing.T) {
 	})
 
 	t.Run("idempotent rejoin updates name", func(t *testing.T) {
-		ss, err := joinSession(JoinSessionParams{SessionID: sessionID, UserID: studentID, Name: "Alice Updated"})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		ss, err := s.JoinSession(ctx, JoinSessionParams{SessionID: sessionID, UserID: studentID, Name: "Alice Updated"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -545,7 +471,7 @@ func TestIntegration_JoinSession(t *testing.T) {
 }
 
 // =============================================================================
-// Test: UpdateCode
+// Test: UpdateCode - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_UpdateCode(t *testing.T) {
@@ -554,7 +480,6 @@ func TestIntegration_UpdateCode(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-update-code"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -564,40 +489,25 @@ func TestIntegration_UpdateCode(t *testing.T) {
 	db.createClass(ctx, t, classID, nsID, "CS101", creatorID)
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN1")
+	// Instructor needs section membership for session update (last_activity)
+	db.createMembership(ctx, t, creatorID, sectionID, "instructor")
 	sessionID := uuid.New()
 	db.createSession(ctx, t, sessionID, nsID, sectionID, "Section A", creatorID)
 	db.createSessionStudent(ctx, t, sessionID, studentID, "Alice")
 
-	updateCode := func(sessID, userID uuid.UUID, code string) (*SessionStudent, error) {
-		tx, err := db.pool.Begin(ctx)
-		if err != nil {
-			return nil, err
-		}
-		defer tx.Rollback(ctx) //nolint:errcheck
-
-		var ss SessionStudent
-		err = tx.QueryRow(ctx,
-			`UPDATE session_students SET code = $3, last_update = now()
-			 WHERE session_id = $1 AND user_id = $2
-			 RETURNING id, session_id, user_id, name, code, execution_settings, last_update`,
-			sessID, userID, code,
-		).Scan(&ss.ID, &ss.SessionID, &ss.UserID, &ss.Name, &ss.Code, &ss.ExecutionSettings, &ss.LastUpdate)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-
-		_, err = tx.Exec(ctx, "UPDATE sessions SET last_activity = now() WHERE id = $1", sessID)
-		if err != nil {
-			return nil, err
-		}
-		if err := tx.Commit(ctx); err != nil {
-			return nil, err
-		}
-		return &ss, nil
+	// Use instructor as auth user - UpdateCode updates sessions.last_activity which requires session update permission
+	authUser := &auth.User{
+		ID:          creatorID,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("update code", func(t *testing.T) {
-		ss, err := updateCode(sessionID, studentID, "x = 42")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		ss, err := s.UpdateCode(ctx, sessionID, studentID, "x = 42")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -607,7 +517,10 @@ func TestIntegration_UpdateCode(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := updateCode(sessionID, uuid.New(), "code")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.UpdateCode(ctx, sessionID, uuid.New(), "code")
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -615,7 +528,7 @@ func TestIntegration_UpdateCode(t *testing.T) {
 }
 
 // =============================================================================
-// Test: ListSessionStudents
+// Test: ListSessionStudents - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListSessionStudents(t *testing.T) {
@@ -624,7 +537,6 @@ func TestIntegration_ListSessionStudents(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-list-ss"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -642,34 +554,21 @@ func TestIntegration_ListSessionStudents(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	db.createSessionStudent(ctx, t, sessionID, s2, "Student 2")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listStudents := func(sessID uuid.UUID) []SessionStudent {
-		t.Helper()
-		rows, err := conn.Query(ctx,
-			`SELECT id, session_id, user_id, name, code, execution_settings, last_update
-			 FROM session_students WHERE session_id = $1 ORDER BY last_update DESC`, sessID)
-		if err != nil {
-			t.Fatalf("query: %v", err)
-		}
-		defer rows.Close()
-		var students []SessionStudent
-		for rows.Next() {
-			var ss SessionStudent
-			if err := rows.Scan(&ss.ID, &ss.SessionID, &ss.UserID, &ss.Name, &ss.Code, &ss.ExecutionSettings, &ss.LastUpdate); err != nil {
-				t.Fatalf("scan: %v", err)
-			}
-			students = append(students, ss)
-		}
-		return students
+	authUser := &auth.User{
+		ID:          creatorID,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("returns students desc by last_update", func(t *testing.T) {
-		results := listStudents(sessionID)
+		store, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := store.ListSessionStudents(ctx, sessionID)
+		if err != nil {
+			t.Fatalf("ListSessionStudents: %v", err)
+		}
 		if len(results) != 2 {
 			t.Fatalf("expected 2 students, got %d", len(results))
 		}
@@ -680,7 +579,13 @@ func TestIntegration_ListSessionStudents(t *testing.T) {
 	})
 
 	t.Run("empty session", func(t *testing.T) {
-		results := listStudents(uuid.New())
+		store, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := store.ListSessionStudents(ctx, uuid.New())
+		if err != nil {
+			t.Fatalf("ListSessionStudents: %v", err)
+		}
 		if len(results) != 0 {
 			t.Errorf("expected 0 students, got %d", len(results))
 		}
@@ -688,7 +593,7 @@ func TestIntegration_ListSessionStudents(t *testing.T) {
 }
 
 // =============================================================================
-// Test: GetSessionStudent
+// Test: GetSessionStudent - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_GetSessionStudent(t *testing.T) {
@@ -697,7 +602,6 @@ func TestIntegration_GetSessionStudent(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-get-ss"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -711,26 +615,18 @@ func TestIntegration_GetSessionStudent(t *testing.T) {
 	db.createSession(ctx, t, sessionID, nsID, sectionID, "Section A", creatorID)
 	db.createSessionStudent(ctx, t, sessionID, studentID, "Alice")
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getSessionStudent := func(sessID, userID uuid.UUID) (*SessionStudent, error) {
-		var ss SessionStudent
-		err := conn.QueryRow(ctx,
-			`SELECT id, session_id, user_id, name, code, execution_settings, last_update
-			 FROM session_students WHERE session_id = $1 AND user_id = $2`,
-			sessID, userID).Scan(&ss.ID, &ss.SessionID, &ss.UserID, &ss.Name, &ss.Code, &ss.ExecutionSettings, &ss.LastUpdate)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &ss, nil
+	authUser := &auth.User{
+		ID:          creatorID,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		ss, err := getSessionStudent(sessionID, studentID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		ss, err := s.GetSessionStudent(ctx, sessionID, studentID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -740,7 +636,10 @@ func TestIntegration_GetSessionStudent(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getSessionStudent(sessionID, uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetSessionStudent(ctx, sessionID, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -748,7 +647,7 @@ func TestIntegration_GetSessionStudent(t *testing.T) {
 }
 
 // =============================================================================
-// Test: CreateRevision
+// Test: CreateRevision - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_CreateRevision(t *testing.T) {
@@ -757,7 +656,6 @@ func TestIntegration_CreateRevision(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-create-rev"
 
 	creatorID := uuid.New()
 	db.createUser(ctx, t, creatorID, "creator@test.com", "instructor", nsID)
@@ -768,24 +666,27 @@ func TestIntegration_CreateRevision(t *testing.T) {
 	sessionID := uuid.New()
 	db.createSession(ctx, t, sessionID, nsID, sectionID, "Section A", creatorID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	authUser := &auth.User{
+		ID:          creatorID,
+		Email:       "creator@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
-	defer conn.Release()
 
 	t.Run("create full code revision", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		fullCode := "print('hello')"
 		execResult := json.RawMessage(`{"status":"ok"}`)
-		var rev Revision
-		err := conn.QueryRow(ctx,
-			`INSERT INTO revisions (namespace_id, session_id, user_id, is_diff, diff, full_code, base_revision_id, execution_result)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-			 RETURNING id, namespace_id, session_id, user_id, timestamp,
-			           is_diff, diff, full_code, base_revision_id, execution_result`,
-			nsID, sessionID, creatorID, false, nil, &fullCode, nil, execResult,
-		).Scan(&rev.ID, &rev.NamespaceID, &rev.SessionID, &rev.UserID, &rev.Timestamp,
-			&rev.IsDiff, &rev.Diff, &rev.FullCode, &rev.BaseRevisionID, &rev.ExecutionResult)
+		rev, err := s.CreateRevision(ctx, CreateRevisionParams{
+			NamespaceID:     nsID,
+			SessionID:       sessionID,
+			UserID:          creatorID,
+			IsDiff:          false,
+			FullCode:        &fullCode,
+			ExecutionResult: execResult,
+		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -805,7 +706,7 @@ func TestIntegration_CreateRevision(t *testing.T) {
 }
 
 // =============================================================================
-// Test: ListRevisions
+// Test: ListRevisions - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListRevisions(t *testing.T) {
@@ -814,7 +715,6 @@ func TestIntegration_ListRevisions(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-list-rev"
 
 	user1 := uuid.New()
 	user2 := uuid.New()
@@ -824,69 +724,84 @@ func TestIntegration_ListRevisions(t *testing.T) {
 	db.createClass(ctx, t, classID, nsID, "CS101", user1)
 	sectionID := uuid.New()
 	db.createSection(ctx, t, sectionID, nsID, classID, "Section A", "JOIN1")
+	// Instructor needs section membership to see revisions
+	db.createMembership(ctx, t, user1, sectionID, "instructor")
+	db.createMembership(ctx, t, user2, sectionID, "student")
 	sessionID := uuid.New()
 	db.createSession(ctx, t, sessionID, nsID, sectionID, "Section A", user1)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	authUser1 := &auth.User{
+		ID:          user1,
+		Email:       "u1@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
-	defer conn.Release()
 
-	// Insert revisions
+	authUser2 := &auth.User{
+		ID:          user2,
+		Email:       "u2@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleStudent,
+	}
+
+	// Insert revisions using Store methods - each user creates their own revision
 	code1 := "code1"
 	code2 := "code2"
-	_, err = conn.Exec(ctx,
-		`INSERT INTO revisions (namespace_id, session_id, user_id, is_diff, full_code, execution_result) VALUES ($1, $2, $3, false, $4, '{}')`,
-		nsID, sessionID, user1, &code1)
+	s, conn := db.storeWithRLS(ctx, t, authUser1)
+	_, err := s.CreateRevision(ctx, CreateRevisionParams{
+		NamespaceID:     nsID,
+		SessionID:       sessionID,
+		UserID:          user1,
+		IsDiff:          false,
+		FullCode:        &code1,
+		ExecutionResult: json.RawMessage(`{}`),
+	})
 	if err != nil {
-		t.Fatalf("insert rev1: %v", err)
+		t.Fatalf("create rev1: %v", err)
 	}
-	time.Sleep(10 * time.Millisecond)
-	_, err = conn.Exec(ctx,
-		`INSERT INTO revisions (namespace_id, session_id, user_id, is_diff, full_code, execution_result) VALUES ($1, $2, $3, false, $4, '{}')`,
-		nsID, sessionID, user2, &code2)
-	if err != nil {
-		t.Fatalf("insert rev2: %v", err)
-	}
+	conn.Release()
 
-	listRevisions := func(sessID uuid.UUID, userID *uuid.UUID) []Revision {
-		t.Helper()
-		query := `SELECT id, namespace_id, session_id, user_id, timestamp,
-		                 is_diff, diff, full_code, base_revision_id, execution_result
-		          FROM revisions WHERE session_id = $1`
-		args := []any{sessID}
-		if userID != nil {
-			query += " AND user_id = $2"
-			args = append(args, *userID)
-		}
-		query += " ORDER BY timestamp"
-		rows, err := conn.Query(ctx, query, args...)
-		if err != nil {
-			t.Fatalf("query: %v", err)
-		}
-		defer rows.Close()
-		var revs []Revision
-		for rows.Next() {
-			var r Revision
-			if err := rows.Scan(&r.ID, &r.NamespaceID, &r.SessionID, &r.UserID, &r.Timestamp,
-				&r.IsDiff, &r.Diff, &r.FullCode, &r.BaseRevisionID, &r.ExecutionResult); err != nil {
-				t.Fatalf("scan: %v", err)
-			}
-			revs = append(revs, r)
-		}
-		return revs
+	time.Sleep(10 * time.Millisecond)
+
+	// User2 creates their own revision
+	s2, conn2 := db.storeWithRLS(ctx, t, authUser2)
+	_, err = s2.CreateRevision(ctx, CreateRevisionParams{
+		NamespaceID:     nsID,
+		SessionID:       sessionID,
+		UserID:          user2,
+		IsDiff:          false,
+		FullCode:        &code2,
+		ExecutionResult: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("create rev2: %v", err)
 	}
+	conn2.Release()
+
+	// Use user1 (instructor) as auth for listing
+	authUser := authUser1
 
 	t.Run("all revisions for session", func(t *testing.T) {
-		results := listRevisions(sessionID, nil)
+		store, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := store.ListRevisions(ctx, sessionID, nil)
+		if err != nil {
+			t.Fatalf("ListRevisions: %v", err)
+		}
 		if len(results) != 2 {
 			t.Fatalf("expected 2 revisions, got %d", len(results))
 		}
 	})
 
 	t.Run("filter by user_id", func(t *testing.T) {
-		results := listRevisions(sessionID, &user1)
+		store, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := store.ListRevisions(ctx, sessionID, &user1)
+		if err != nil {
+			t.Fatalf("ListRevisions: %v", err)
+		}
 		if len(results) != 1 {
 			t.Fatalf("expected 1 revision, got %d", len(results))
 		}
@@ -896,7 +811,13 @@ func TestIntegration_ListRevisions(t *testing.T) {
 	})
 
 	t.Run("empty session", func(t *testing.T) {
-		results := listRevisions(uuid.New(), nil)
+		store, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := store.ListRevisions(ctx, uuid.New(), nil)
+		if err != nil {
+			t.Fatalf("ListRevisions: %v", err)
+		}
 		if len(results) != 0 {
 			t.Errorf("expected 0 revisions, got %d", len(results))
 		}
@@ -904,7 +825,7 @@ func TestIntegration_ListRevisions(t *testing.T) {
 }
 
 // =============================================================================
-// Test: CreateProblem
+// Test: CreateProblem - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_CreateProblem(t *testing.T) {
@@ -913,36 +834,41 @@ func TestIntegration_CreateProblem(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-create-problem"
 
 	authorID := uuid.New()
 	db.createUser(ctx, t, authorID, "author@test.com", "instructor", nsID)
 	classID := uuid.New()
 	db.createClass(ctx, t, classID, nsID, "CS101", authorID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
+	authUser := &auth.User{
+		ID:          authorID,
+		Email:       "author@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
-	defer conn.Release()
 
 	t.Run("successful creation", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		desc := "Find two numbers that sum to target"
 		starter := "def two_sum(nums, target):"
 		solution := "return [0, 1]"
 		testCases := json.RawMessage(`[{"input":[1,2],"output":3}]`)
 		execSettings := json.RawMessage(`{"timeout":5}`)
 
-		var p Problem
-		err := conn.QueryRow(ctx,
-			`INSERT INTO problems (namespace_id, title, description, starter_code, test_cases,
-			                       execution_settings, author_id, class_id, tags, solution)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-			 RETURNING id, namespace_id, title, description, starter_code, test_cases,
-			           execution_settings, author_id, class_id, tags, solution, created_at, updated_at`,
-			nsID, "Two Sum", &desc, &starter, testCases, execSettings, authorID, &classID, []string{"easy", "arrays"}, &solution,
-		).Scan(&p.ID, &p.NamespaceID, &p.Title, &p.Description, &p.StarterCode, &p.TestCases,
-			&p.ExecutionSettings, &p.AuthorID, &p.ClassID, &p.Tags, &p.Solution, &p.CreatedAt, &p.UpdatedAt)
+		p, err := s.CreateProblem(ctx, CreateProblemParams{
+			NamespaceID:       nsID,
+			Title:             "Two Sum",
+			Description:       &desc,
+			StarterCode:       &starter,
+			TestCases:         testCases,
+			ExecutionSettings: execSettings,
+			AuthorID:          authorID,
+			ClassID:           &classID,
+			Tags:              []string{"easy", "arrays"},
+			Solution:          &solution,
+		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -965,7 +891,7 @@ func TestIntegration_CreateProblem(t *testing.T) {
 }
 
 // =============================================================================
-// Test: GetProblem
+// Test: GetProblem - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_GetProblem(t *testing.T) {
@@ -974,35 +900,24 @@ func TestIntegration_GetProblem(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-get-problem"
 
 	authorID := uuid.New()
 	db.createUser(ctx, t, authorID, "author@test.com", "instructor", nsID)
 	problemID := uuid.New()
 	db.createProblem(ctx, t, problemID, nsID, "Test Problem", authorID, nil, []string{"easy"})
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getProblem := func(id uuid.UUID) (*Problem, error) {
-		var p Problem
-		err := conn.QueryRow(ctx,
-			`SELECT id, namespace_id, title, description, starter_code, test_cases,
-			        execution_settings, author_id, class_id, tags, solution, created_at, updated_at
-			 FROM problems WHERE id = $1`, id).Scan(
-			&p.ID, &p.NamespaceID, &p.Title, &p.Description, &p.StarterCode, &p.TestCases,
-			&p.ExecutionSettings, &p.AuthorID, &p.ClassID, &p.Tags, &p.Solution, &p.CreatedAt, &p.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &p, nil
+	authUser := &auth.User{
+		ID:          authorID,
+		Email:       "author@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		p, err := getProblem(problemID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		p, err := s.GetProblem(ctx, problemID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1012,7 +927,10 @@ func TestIntegration_GetProblem(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getProblem(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetProblem(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -1020,7 +938,7 @@ func TestIntegration_GetProblem(t *testing.T) {
 }
 
 // =============================================================================
-// Test: UpdateProblem
+// Test: UpdateProblem - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_UpdateProblem(t *testing.T) {
@@ -1029,70 +947,25 @@ func TestIntegration_UpdateProblem(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-update-problem"
 
 	authorID := uuid.New()
 	db.createUser(ctx, t, authorID, "author@test.com", "instructor", nsID)
 	problemID := uuid.New()
 	db.createProblem(ctx, t, problemID, nsID, "Original Title", authorID, nil, []string{"easy"})
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	updateProblem := func(id uuid.UUID, params UpdateProblemParams) (*Problem, error) {
-		query := `UPDATE problems
-		SET title             = COALESCE($2, title),
-		    description       = COALESCE($3, description),
-		    starter_code      = COALESCE($4, starter_code)`
-		args := []any{id, params.Title, params.Description, params.StarterCode}
-		argIdx := 5
-
-		if params.TestCases != nil {
-			query += fmt.Sprintf(",\n		    test_cases         = $%d", argIdx)
-			args = append(args, params.TestCases)
-			argIdx++
-		}
-		if params.ExecutionSettings != nil {
-			query += fmt.Sprintf(",\n		    execution_settings = $%d", argIdx)
-			args = append(args, params.ExecutionSettings)
-			argIdx++
-		}
-		if params.ClassID != nil {
-			query += fmt.Sprintf(",\n		    class_id           = $%d", argIdx)
-			args = append(args, *params.ClassID)
-			argIdx++
-		}
-		if params.Tags != nil {
-			query += fmt.Sprintf(",\n		    tags               = $%d", argIdx)
-			args = append(args, params.Tags)
-			argIdx++
-		}
-		if params.Solution != nil {
-			query += fmt.Sprintf(",\n		    solution           = $%d", argIdx)
-			args = append(args, *params.Solution)
-		}
-		query += `,
-		    updated_at        = now()
-		WHERE id = $1
-		RETURNING id, namespace_id, title, description, starter_code, test_cases,
-		          execution_settings, author_id, class_id, tags, solution, created_at, updated_at`
-
-		var p Problem
-		err := conn.QueryRow(ctx, query, args...).Scan(
-			&p.ID, &p.NamespaceID, &p.Title, &p.Description, &p.StarterCode, &p.TestCases,
-			&p.ExecutionSettings, &p.AuthorID, &p.ClassID, &p.Tags, &p.Solution, &p.CreatedAt, &p.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &p, nil
+	authUser := &auth.User{
+		ID:          authorID,
+		Email:       "author@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("partial update title only", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newTitle := "Updated Title"
-		p, err := updateProblem(problemID, UpdateProblemParams{Title: &newTitle})
+		p, err := s.UpdateProblem(ctx, problemID, UpdateProblemParams{Title: &newTitle})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1102,8 +975,11 @@ func TestIntegration_UpdateProblem(t *testing.T) {
 	})
 
 	t.Run("update tags", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		newTitle := "Updated Title"
-		p, err := updateProblem(problemID, UpdateProblemParams{Title: &newTitle, Tags: []string{"medium", "trees"}})
+		p, err := s.UpdateProblem(ctx, problemID, UpdateProblemParams{Title: &newTitle, Tags: []string{"medium", "trees"}})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1113,8 +989,11 @@ func TestIntegration_UpdateProblem(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		title := "nope"
-		_, err := updateProblem(uuid.New(), UpdateProblemParams{Title: &title})
+		_, err := s.UpdateProblem(ctx, uuid.New(), UpdateProblemParams{Title: &title})
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -1122,7 +1001,7 @@ func TestIntegration_UpdateProblem(t *testing.T) {
 }
 
 // =============================================================================
-// Test: DeleteProblem
+// Test: DeleteProblem - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_DeleteProblem(t *testing.T) {
@@ -1131,36 +1010,28 @@ func TestIntegration_DeleteProblem(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-delete-problem"
 
 	authorID := uuid.New()
 	db.createUser(ctx, t, authorID, "author@test.com", "instructor", nsID)
 	problemID := uuid.New()
 	db.createProblem(ctx, t, problemID, nsID, "To Delete", authorID, nil, nil)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	deleteProblem := func(id uuid.UUID) error {
-		tag, err := conn.Exec(ctx, "DELETE FROM problems WHERE id = $1", id)
-		if err != nil {
-			return err
-		}
-		if tag.RowsAffected() == 0 {
-			return ErrNotFound
-		}
-		return nil
+	authUser := &auth.User{
+		ID:          authorID,
+		Email:       "author@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("delete existing", func(t *testing.T) {
-		if err := deleteProblem(problemID); err != nil {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		if err := s.DeleteProblem(ctx, problemID); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		var count int
-		err = db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM problems WHERE id = $1", problemID).Scan(&count)
+		err := db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM problems WHERE id = $1", problemID).Scan(&count)
 		if err != nil {
 			t.Fatalf("count: %v", err)
 		}
@@ -1170,7 +1041,10 @@ func TestIntegration_DeleteProblem(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		err := deleteProblem(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		err := s.DeleteProblem(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -1178,7 +1052,7 @@ func TestIntegration_DeleteProblem(t *testing.T) {
 }
 
 // =============================================================================
-// Test: ListProblems
+// Test: ListProblems - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_ListProblems(t *testing.T) {
@@ -1187,7 +1061,6 @@ func TestIntegration_ListProblems(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-list-problems"
 
 	authorID := uuid.New()
 	db.createUser(ctx, t, authorID, "author@test.com", "instructor", nsID)
@@ -1200,43 +1073,21 @@ func TestIntegration_ListProblems(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	db.createProblem(ctx, t, p2, nsID, "Problem B", authorID, nil, nil)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	listProblems := func(classFilter *uuid.UUID) []Problem {
-		t.Helper()
-		query := `SELECT id, namespace_id, title, description, starter_code, test_cases,
-		                 execution_settings, author_id, class_id, tags, solution, created_at, updated_at
-		          FROM problems`
-		var args []any
-		if classFilter != nil {
-			query += " WHERE class_id = $1"
-			args = append(args, *classFilter)
-		}
-		query += " ORDER BY created_at"
-		rows, err := conn.Query(ctx, query, args...)
-		if err != nil {
-			t.Fatalf("query: %v", err)
-		}
-		defer rows.Close()
-		var problems []Problem
-		for rows.Next() {
-			var p Problem
-			if err := rows.Scan(&p.ID, &p.NamespaceID, &p.Title, &p.Description, &p.StarterCode,
-				&p.TestCases, &p.ExecutionSettings, &p.AuthorID, &p.ClassID, &p.Tags, &p.Solution,
-				&p.CreatedAt, &p.UpdatedAt); err != nil {
-				t.Fatalf("scan: %v", err)
-			}
-			problems = append(problems, p)
-		}
-		return problems
+	authUser := &auth.User{
+		ID:          authorID,
+		Email:       "author@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleInstructor,
 	}
 
 	t.Run("no filter", func(t *testing.T) {
-		results := listProblems(nil)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblems(ctx, nil)
+		if err != nil {
+			t.Fatalf("ListProblems: %v", err)
+		}
 		if len(results) != 2 {
 			t.Errorf("expected 2 problems, got %d", len(results))
 		}
@@ -1246,7 +1097,13 @@ func TestIntegration_ListProblems(t *testing.T) {
 	})
 
 	t.Run("filter by class_id", func(t *testing.T) {
-		results := listProblems(&classID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		results, err := s.ListProblems(ctx, &classID)
+		if err != nil {
+			t.Fatalf("ListProblems: %v", err)
+		}
 		if len(results) != 1 {
 			t.Errorf("expected 1 problem in class, got %d", len(results))
 		}
@@ -1254,7 +1111,7 @@ func TestIntegration_ListProblems(t *testing.T) {
 }
 
 // =============================================================================
-// Test: GetUserByID
+// Test: GetUserByID - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_GetUserByID(t *testing.T) {
@@ -1263,31 +1120,22 @@ func TestIntegration_GetUserByID(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-get-user-id"
 
 	userID := uuid.New()
 	db.createUser(ctx, t, userID, "byid@test.com", "student", nsID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getUserByID := func(id uuid.UUID) (*User, error) {
-		var u User
-		err := conn.QueryRow(ctx,
-			`SELECT id, external_id, email, role, namespace_id, display_name, created_at, updated_at
-			 FROM users WHERE id = $1`, id).Scan(
-			&u.ID, &u.ExternalID, &u.Email, &u.Role, &u.NamespaceID, &u.DisplayName, &u.CreatedAt, &u.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &u, nil
+	authUser := &auth.User{
+		ID:          userID,
+		Email:       "byid@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleStudent,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		u, err := getUserByID(userID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		u, err := s.GetUserByID(ctx, userID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1300,7 +1148,10 @@ func TestIntegration_GetUserByID(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getUserByID(uuid.New())
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetUserByID(ctx, uuid.New())
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -1308,7 +1159,7 @@ func TestIntegration_GetUserByID(t *testing.T) {
 }
 
 // =============================================================================
-// Test: GetUserByExternalID
+// Test: GetUserByExternalID - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_GetUserByExternalID(t *testing.T) {
@@ -1317,7 +1168,6 @@ func TestIntegration_GetUserByExternalID(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-get-user-ext"
 
 	userID := uuid.New()
 	extID := "firebase-uid-" + uuid.New().String()[:8]
@@ -1329,26 +1179,18 @@ func TestIntegration_GetUserByExternalID(t *testing.T) {
 		t.Fatalf("create user: %v", err)
 	}
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	getUserByExternalID := func(externalID string) (*User, error) {
-		var u User
-		err := conn.QueryRow(ctx,
-			`SELECT id, external_id, email, role, namespace_id, display_name, created_at, updated_at
-			 FROM users WHERE external_id = $1`, externalID).Scan(
-			&u.ID, &u.ExternalID, &u.Email, &u.Role, &u.NamespaceID, &u.DisplayName, &u.CreatedAt, &u.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &u, nil
+	authUser := &auth.User{
+		ID:          userID,
+		Email:       "ext@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleStudent,
 	}
 
 	t.Run("found", func(t *testing.T) {
-		u, err := getUserByExternalID(extID)
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		u, err := s.GetUserByExternalID(ctx, extID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1361,7 +1203,10 @@ func TestIntegration_GetUserByExternalID(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := getUserByExternalID("nonexistent-uid")
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		_, err := s.GetUserByExternalID(ctx, "nonexistent-uid")
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -1369,7 +1214,7 @@ func TestIntegration_GetUserByExternalID(t *testing.T) {
 }
 
 // =============================================================================
-// Test: UpdateUser
+// Test: UpdateUser - calls actual Store method with RLS
 // =============================================================================
 
 func TestIntegration_UpdateUser(t *testing.T) {
@@ -1378,35 +1223,23 @@ func TestIntegration_UpdateUser(t *testing.T) {
 	ctx := context.Background()
 
 	nsID := db.nsID
-	// was "test-ns-update-user"
 
 	userID := uuid.New()
 	db.createUser(ctx, t, userID, "update@test.com", "student", nsID)
 
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire: %v", err)
-	}
-	defer conn.Release()
-
-	updateUser := func(id uuid.UUID, params UpdateUserParams) (*User, error) {
-		var u User
-		err := conn.QueryRow(ctx,
-			`UPDATE users
-			 SET display_name = COALESCE($2, display_name), updated_at = now()
-			 WHERE id = $1
-			 RETURNING id, external_id, email, role, namespace_id, display_name, created_at, updated_at`,
-			id, params.DisplayName).Scan(
-			&u.ID, &u.ExternalID, &u.Email, &u.Role, &u.NamespaceID, &u.DisplayName, &u.CreatedAt, &u.UpdatedAt)
-		if err != nil {
-			return nil, HandleNotFound(err)
-		}
-		return &u, nil
+	authUser := &auth.User{
+		ID:          userID,
+		Email:       "update@test.com",
+		NamespaceID: nsID,
+		Role:        auth.RoleStudent,
 	}
 
 	t.Run("update display name", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		name := "New Name"
-		u, err := updateUser(userID, UpdateUserParams{DisplayName: &name})
+		u, err := s.UpdateUser(ctx, userID, UpdateUserParams{DisplayName: &name})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1416,7 +1249,10 @@ func TestIntegration_UpdateUser(t *testing.T) {
 	})
 
 	t.Run("nil display name keeps current", func(t *testing.T) {
-		u, err := updateUser(userID, UpdateUserParams{DisplayName: nil})
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
+		u, err := s.UpdateUser(ctx, userID, UpdateUserParams{DisplayName: nil})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1426,8 +1262,11 @@ func TestIntegration_UpdateUser(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		s, conn := db.storeWithRLS(ctx, t, authUser)
+		defer conn.Release()
+
 		name := "nope"
-		_, err := updateUser(uuid.New(), UpdateUserParams{DisplayName: &name})
+		_, err := s.UpdateUser(ctx, uuid.New(), UpdateUserParams{DisplayName: &name})
 		if !errors.Is(err, ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
@@ -1436,4 +1275,3 @@ func TestIntegration_UpdateUser(t *testing.T) {
 
 // Ensure imports are used.
 var _ = json.RawMessage{}
-var _ = fmt.Sprintf


### PR DESCRIPTION
## Summary
- Refactor all store integration tests to use Store methods with proper RLS context instead of raw SQL
- Add `storeWithRLS()` helper that sets up RLS session variables before queries
- Tests now properly exercise RLS policies by using appropriate role contexts

## Changes
- **store_methods_integration_test.go**: Added `storeWithRLS()`, `bootstrapUser()`, `bootstrapNamespace()` helpers. Rewrote all tests to use Store methods.
- **store_crud_integration_test.go**: Rewrote namespace, class, section, and membership CRUD tests to use proper RLS context
- **store_session_integration_test.go**: Rewrote session, session_student, and revision tests to use proper RLS context

## Test plan
- [x] All store integration tests pass locally
- [x] Tests properly verify RLS enforcement (e.g., ListProblems only sees namespace-scoped data)

Beads: PLAT-1xo, PLAT-1xo.1, PLAT-1xo.2, PLAT-1xo.3, PLAT-1xo.4

Note: PLAT-1xo.5 (namespace isolation tests) is deferred as follow-on work.

Generated with Claude Code