### PR TITLE
feat: implement /trace endpoint in executor service

### DIFF
--- a/executor/go.mod
+++ b/executor/go.mod
@@ -31,10 +31,10 @@ require (
 
 replace github.com/jdelfino/eval/pkg/executorapi => ../pkg/executorapi
 
+replace github.com/jdelfino/eval/pkg/httputil => ../pkg/httputil
+
 replace github.com/jdelfino/eval/pkg/httplog => ../pkg/httplog
 
 replace github.com/jdelfino/eval/pkg/slogutil => ../pkg/slogutil
 
 replace github.com/jdelfino/eval/pkg/httpmiddleware => ../pkg/httpmiddleware
-
-replace github.com/jdelfino/eval/pkg/httputil => ../pkg/httputil

--- a/executor/internal/handler/trace.go
+++ b/executor/internal/handler/trace.go
@@ -1,0 +1,223 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jdelfino/eval/executor/internal/metrics"
+	"github.com/jdelfino/eval/executor/internal/sandbox"
+	"github.com/jdelfino/eval/executor/internal/tracer"
+	"github.com/jdelfino/eval/pkg/executorapi"
+	"github.com/jdelfino/eval/pkg/httputil"
+)
+
+// maxTraceSteps is the hard cap on max_steps for trace requests.
+const maxTraceSteps = 50000
+
+// defaultTraceSteps is used when max_steps is not provided.
+const defaultTraceSteps = 5000
+
+// traceTimeoutMs is the timeout for trace executions (10 seconds).
+const traceTimeoutMs = 10000
+
+// TraceHandlerConfig holds configuration values for the TraceHandler.
+type TraceHandlerConfig struct {
+	NsjailPath              string
+	PythonPath              string
+	MaxOutputBytes          int
+	MaxCodeBytes            int
+	MaxStdinBytes           int
+	MaxConcurrentExecutions int
+}
+
+// TraceHandler handles debugger trace requests.
+type TraceHandler struct {
+	logger    *slog.Logger
+	runner    SandboxRunner
+	metrics   *metrics.Metrics
+	cfg       TraceHandlerConfig
+	semaphore chan struct{}
+}
+
+// NewTraceHandler creates a TraceHandler with the given dependencies.
+func NewTraceHandler(
+	logger *slog.Logger,
+	runner SandboxRunner,
+	m *metrics.Metrics,
+	cfg TraceHandlerConfig,
+) *TraceHandler {
+	var sem chan struct{}
+	if cfg.MaxConcurrentExecutions > 0 {
+		sem = make(chan struct{}, cfg.MaxConcurrentExecutions)
+	}
+	return &TraceHandler{
+		logger:    logger,
+		runner:    runner,
+		metrics:   m,
+		cfg:       cfg,
+		semaphore: sem,
+	}
+}
+
+// ServeHTTP handles the /trace endpoint.
+func (h *TraceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	// Limit body size.
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	var req executorapi.TraceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.metrics.ValidationErrorsTotal.WithLabelValues("invalid_request").Inc()
+		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Validate request.
+	if reason, errMsg := h.validateRequest(&req); errMsg != "" {
+		if reason != "" {
+			h.metrics.ValidationErrorsTotal.WithLabelValues(reason).Inc()
+		}
+		httputil.WriteError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	// Try to acquire a concurrency slot (non-blocking).
+	if h.semaphore != nil {
+		select {
+		case h.semaphore <- struct{}{}:
+			defer func() { <-h.semaphore }()
+		default:
+			h.logger.Warn("concurrency limit reached, rejecting trace request")
+			httputil.WriteError(w, http.StatusTooManyRequests, "too many concurrent executions")
+			return
+		}
+	}
+
+	// Observe code size.
+	h.metrics.CodeSizeBytes.Observe(float64(len(req.Code)))
+
+	// Determine max steps.
+	maxSteps := defaultTraceSteps
+	if req.MaxSteps != nil {
+		maxSteps = *req.MaxSteps
+	}
+
+	// Build the tracer invocation: the tracer script becomes main.py,
+	// and the student code, stdin, and maxSteps are passed as arguments.
+	sandboxReq := sandbox.Request{
+		Code:      tracer.Script,
+		Stdin:     "", // tracer reads stdin via argv, not actual stdin
+		TimeoutMs: traceTimeoutMs,
+		Args:      []string{req.Code, req.Stdin, strconv.Itoa(maxSteps)},
+	}
+
+	sandboxCfg := sandbox.Config{
+		NsjailPath:     h.cfg.NsjailPath,
+		PythonPath:     h.cfg.PythonPath,
+		MaxOutputBytes: h.cfg.MaxOutputBytes,
+	}
+
+	h.logger.Info("tracing code",
+		"code_length", len(req.Code),
+		"has_stdin", req.Stdin != "",
+		"max_steps", maxSteps,
+	)
+
+	// Track active executions.
+	h.metrics.ActiveExecutions.Inc()
+	defer h.metrics.ActiveExecutions.Dec()
+
+	start := time.Now()
+	result, err := h.runner(r.Context(), sandboxCfg, sandboxReq)
+	duration := time.Since(start)
+
+	h.metrics.ExecutionDuration.Observe(duration.Seconds())
+
+	if err != nil {
+		h.logger.Error("trace sandbox execution failed", "error", err, "duration_ms", duration.Milliseconds())
+		h.metrics.ExecutionsTotal.WithLabelValues("error").Inc()
+		httputil.WriteError(w, http.StatusInternalServerError, "internal execution error")
+		return
+	}
+
+	// Handle timeout.
+	if result.TimedOut {
+		h.metrics.ExecutionsTotal.WithLabelValues("timeout").Inc()
+		resp := executorapi.TraceResponse{
+			Steps:     []executorapi.TraceStep{},
+			ExitCode:  -1,
+			Error:     "trace execution timed out",
+			Truncated: true,
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	// Parse the tracer JSON output from stdout.
+	resp, parseErr := parseTraceOutput(result.Stdout)
+	if parseErr != nil {
+		h.logger.Error("failed to parse trace output",
+			"error", parseErr,
+			"stdout_len", len(result.Stdout),
+			"stderr", result.Stderr,
+		)
+		h.metrics.ExecutionsTotal.WithLabelValues("error").Inc()
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to parse trace output")
+		return
+	}
+
+	if resp.ExitCode == 0 {
+		h.metrics.ExecutionsTotal.WithLabelValues("success").Inc()
+	} else {
+		h.metrics.ExecutionsTotal.WithLabelValues("failure").Inc()
+	}
+
+	h.logger.Info("trace complete",
+		"total_steps", resp.TotalSteps,
+		"exit_code", resp.ExitCode,
+		"truncated", resp.Truncated,
+		"duration_ms", duration.Milliseconds(),
+	)
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h *TraceHandler) validateRequest(req *executorapi.TraceRequest) (string, string) {
+	if req.Code == "" {
+		return "invalid_request", "code is required and must be non-empty"
+	}
+	if len(req.Code) > h.cfg.MaxCodeBytes {
+		return "code_too_large", fmt.Sprintf("code exceeds maximum size of %d bytes", h.cfg.MaxCodeBytes)
+	}
+	if len(req.Stdin) > h.cfg.MaxStdinBytes {
+		return "stdin_too_large", fmt.Sprintf("stdin exceeds maximum size of %d bytes", h.cfg.MaxStdinBytes)
+	}
+	if req.MaxSteps != nil {
+		if *req.MaxSteps <= 0 {
+			return "invalid_request", "max_steps must be a positive integer"
+		}
+		if *req.MaxSteps > maxTraceSteps {
+			return "invalid_request", fmt.Sprintf("max_steps exceeds maximum of %d", maxTraceSteps)
+		}
+	}
+	return "", ""
+}
+
+func parseTraceOutput(stdout string) (*executorapi.TraceResponse, error) {
+	var resp executorapi.TraceResponse
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal trace output: %w", err)
+	}
+	// Ensure steps is never nil for clean JSON serialization.
+	if resp.Steps == nil {
+		resp.Steps = []executorapi.TraceStep{}
+	}
+	return &resp, nil
+}

--- a/executor/internal/handler/trace_test.go
+++ b/executor/internal/handler/trace_test.go
@@ -1,0 +1,447 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jdelfino/eval/executor/internal/handler"
+	"github.com/jdelfino/eval/executor/internal/metrics"
+	"github.com/jdelfino/eval/executor/internal/sandbox"
+	"github.com/jdelfino/eval/pkg/executorapi"
+)
+
+func defaultTraceConfig() handler.TraceHandlerConfig {
+	return handler.TraceHandlerConfig{
+		NsjailPath:       "/usr/bin/nsjail",
+		PythonPath:       "/usr/bin/python3",
+		MaxOutputBytes:   1048576,
+		MaxCodeBytes:     102400,
+		MaxStdinBytes:    1048576,
+	}
+}
+
+func newTraceHandler(runner handler.SandboxRunner, m *metrics.Metrics, cfg handler.TraceHandlerConfig) http.HandlerFunc {
+	h := handler.NewTraceHandler(noopLogger(), runner, m, cfg)
+	return h.ServeHTTP
+}
+
+func doTraceRequest(h http.HandlerFunc, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/trace", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+// traceSuccessRunner returns a sandbox result with valid tracer JSON output on stdout.
+func traceSuccessRunner(_ context.Context, _ sandbox.Config, _ sandbox.Request) (*sandbox.Result, error) {
+	output := `{"steps":[{"line":1,"event":"line","locals":{"x":5},"globals":{},"call_stack":[],"stdout":""}],"total_steps":1,"exit_code":0,"error":null,"truncated":false}`
+	return &sandbox.Result{
+		Stdout:     output,
+		Stderr:     "",
+		ExitCode:   0,
+		TimedOut:   false,
+		DurationMs: 50,
+	}, nil
+}
+
+// traceMultiStepRunner returns trace output with multiple steps.
+func traceMultiStepRunner(_ context.Context, _ sandbox.Config, _ sandbox.Request) (*sandbox.Result, error) {
+	output := `{"steps":[` +
+		`{"line":1,"event":"line","locals":{},"globals":{},"call_stack":[{"function_name":"<module>","filename":"<string>","line":1}],"stdout":""},` +
+		`{"line":2,"event":"line","locals":{"x":5},"globals":{},"call_stack":[{"function_name":"<module>","filename":"<string>","line":2}],"stdout":""},` +
+		`{"line":3,"event":"line","locals":{"x":5,"y":10},"globals":{},"call_stack":[{"function_name":"<module>","filename":"<string>","line":3}],"stdout":"15\n"}` +
+		`],"total_steps":3,"exit_code":0,"error":null,"truncated":false}`
+	return &sandbox.Result{
+		Stdout:     output,
+		Stderr:     "",
+		ExitCode:   0,
+		TimedOut:   false,
+		DurationMs: 80,
+	}, nil
+}
+
+// traceErrorRunner returns trace output with an error.
+func traceErrorRunner(_ context.Context, _ sandbox.Config, _ sandbox.Request) (*sandbox.Result, error) {
+	output := `{"steps":[{"line":1,"event":"line","locals":{},"globals":{},"call_stack":[],"stdout":""}],"total_steps":1,"exit_code":1,"error":"NameError: name 'x' is not defined","truncated":false}`
+	return &sandbox.Result{
+		Stdout:     output,
+		Stderr:     "",
+		ExitCode:   0,
+		TimedOut:   false,
+		DurationMs: 30,
+	}, nil
+}
+
+// traceTruncatedRunner returns trace output that was truncated at max steps.
+func traceTruncatedRunner(_ context.Context, _ sandbox.Config, _ sandbox.Request) (*sandbox.Result, error) {
+	output := `{"steps":[{"line":1,"event":"line","locals":{},"globals":{},"call_stack":[],"stdout":""}],"total_steps":1,"exit_code":0,"error":null,"truncated":true}`
+	return &sandbox.Result{
+		Stdout:     output,
+		Stderr:     "",
+		ExitCode:   0,
+		TimedOut:   false,
+		DurationMs: 100,
+	}, nil
+}
+
+// traceInvalidOutputRunner returns invalid JSON on stdout.
+func traceInvalidOutputRunner(_ context.Context, _ sandbox.Config, _ sandbox.Request) (*sandbox.Result, error) {
+	return &sandbox.Result{
+		Stdout:     "not valid json",
+		Stderr:     "",
+		ExitCode:   0,
+		TimedOut:   false,
+		DurationMs: 20,
+	}, nil
+}
+
+// traceCaptureRunner records the sandbox request and returns valid trace JSON.
+type traceCaptureRunner struct {
+	req sandbox.Request
+	cfg sandbox.Config
+}
+
+func (c *traceCaptureRunner) run(_ context.Context, cfg sandbox.Config, req sandbox.Request) (*sandbox.Result, error) {
+	c.req = req
+	c.cfg = cfg
+	return &sandbox.Result{
+		Stdout:     `{"steps":[],"total_steps":0,"exit_code":0,"truncated":false}`,
+		ExitCode:   0,
+		DurationMs: 1,
+	}, nil
+}
+
+func TestTrace_Success(t *testing.T) {
+	h := newTraceHandler(traceSuccessRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"x = 5"}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp executorapi.TraceResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(resp.Steps))
+	}
+	if resp.Steps[0].Line != 1 {
+		t.Errorf("expected line 1, got %d", resp.Steps[0].Line)
+	}
+	if resp.Steps[0].Event != "line" {
+		t.Errorf("expected event 'line', got %q", resp.Steps[0].Event)
+	}
+	if resp.TotalSteps != 1 {
+		t.Errorf("expected total_steps=1, got %d", resp.TotalSteps)
+	}
+	if resp.ExitCode != 0 {
+		t.Errorf("expected exit_code=0, got %d", resp.ExitCode)
+	}
+	if resp.Truncated {
+		t.Error("expected truncated=false")
+	}
+}
+
+func TestTrace_MultiStep(t *testing.T) {
+	h := newTraceHandler(traceMultiStepRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"x=5\ny=10\nprint(x+y)"}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp executorapi.TraceResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(resp.Steps))
+	}
+	// Check call stack is populated.
+	if len(resp.Steps[0].CallStack) != 1 {
+		t.Errorf("expected 1 call frame, got %d", len(resp.Steps[0].CallStack))
+	}
+	if resp.Steps[0].CallStack[0].FunctionName != "<module>" {
+		t.Errorf("expected function_name '<module>', got %q", resp.Steps[0].CallStack[0].FunctionName)
+	}
+	// Check stdout accumulates.
+	if resp.Steps[2].Stdout != "15\n" {
+		t.Errorf("expected stdout '15\\n', got %q", resp.Steps[2].Stdout)
+	}
+}
+
+func TestTrace_WithError(t *testing.T) {
+	h := newTraceHandler(traceErrorRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"print(x)"}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp executorapi.TraceResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.ExitCode != 1 {
+		t.Errorf("expected exit_code=1, got %d", resp.ExitCode)
+	}
+	if resp.Error == "" {
+		t.Error("expected non-empty error")
+	}
+}
+
+func TestTrace_Truncated(t *testing.T) {
+	h := newTraceHandler(traceTruncatedRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"while True: pass"}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp executorapi.TraceResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Truncated {
+		t.Error("expected truncated=true")
+	}
+}
+
+func TestTrace_Timeout(t *testing.T) {
+	h := newTraceHandler(timeoutRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"while True: pass"}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp executorapi.TraceResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.ExitCode != -1 {
+		t.Errorf("expected exit_code=-1, got %d", resp.ExitCode)
+	}
+	if resp.Error != "trace execution timed out" {
+		t.Errorf("expected timeout error, got %q", resp.Error)
+	}
+	if !resp.Truncated {
+		t.Error("expected truncated=true for timeout")
+	}
+}
+
+func TestTrace_InternalError(t *testing.T) {
+	h := newTraceHandler(errorRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"x=1"}`)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestTrace_InvalidTracerOutput(t *testing.T) {
+	h := newTraceHandler(traceInvalidOutputRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"x=1"}`)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTrace_EmptyCode(t *testing.T) {
+	h := newTraceHandler(traceSuccessRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":""}`)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTrace_MissingCode(t *testing.T) {
+	h := newTraceHandler(traceSuccessRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{}`)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTrace_InvalidJSON(t *testing.T) {
+	h := newTraceHandler(traceSuccessRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `not json`)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTrace_CodeTooLarge(t *testing.T) {
+	cfg := defaultTraceConfig()
+	cfg.MaxCodeBytes = 10
+	h := newTraceHandler(traceSuccessRunner, metrics.NewNoop(), cfg)
+	w := doTraceRequest(h, `{"code":"print('this is way too long')"}`)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTrace_StdinTooLarge(t *testing.T) {
+	cfg := defaultTraceConfig()
+	cfg.MaxStdinBytes = 5
+	h := newTraceHandler(traceSuccessRunner, metrics.NewNoop(), cfg)
+	w := doTraceRequest(h, `{"code":"x=1","stdin":"toolarge"}`)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTrace_MaxStepsNegative(t *testing.T) {
+	h := newTraceHandler(traceSuccessRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"x=1","max_steps":-1}`)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTrace_MaxStepsTooLarge(t *testing.T) {
+	h := newTraceHandler(traceSuccessRunner, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"x=1","max_steps":999999}`)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTrace_WithStdinAndMaxSteps(t *testing.T) {
+	cap := &traceCaptureRunner{}
+	h := newTraceHandler(cap.run, metrics.NewNoop(), defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"x=1","stdin":"hello","max_steps":100}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify args passed to sandbox: [code, stdin, maxSteps]
+	if len(cap.req.Args) != 3 {
+		t.Fatalf("expected 3 args, got %d", len(cap.req.Args))
+	}
+	if cap.req.Args[0] != "x=1" {
+		t.Errorf("expected arg[0]='x=1', got %q", cap.req.Args[0])
+	}
+	if cap.req.Args[1] != "hello" {
+		t.Errorf("expected arg[1]='hello', got %q", cap.req.Args[1])
+	}
+	if cap.req.Args[2] != "100" {
+		t.Errorf("expected arg[2]='100', got %q", cap.req.Args[2])
+	}
+}
+
+func TestTrace_ConcurrencyLimit(t *testing.T) {
+	entryCh := make(chan struct{})
+	blockCh := make(chan struct{})
+	blockingRunner := func(_ context.Context, _ sandbox.Config, _ sandbox.Request) (*sandbox.Result, error) {
+		close(entryCh)
+		<-blockCh
+		return &sandbox.Result{Stdout: `{"steps":[],"total_steps":0,"exit_code":0,"truncated":false}`, ExitCode: 0, DurationMs: 1}, nil
+	}
+
+	cfg := defaultTraceConfig()
+	cfg.MaxConcurrentExecutions = 1
+	h := handler.NewTraceHandler(noopLogger(), blockingRunner, metrics.NewNoop(), cfg)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		doTraceRequest(h.ServeHTTP, `{"code":"x=1"}`)
+	}()
+
+	// Wait for first request to enter runner.
+	<-entryCh
+
+	// Second request should be rejected.
+	w := doTraceRequest(h.ServeHTTP, `{"code":"x=1"}`)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", w.Code)
+	}
+
+	var errResp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatal(err)
+	}
+	if errResp["error"] != "too many concurrent executions" {
+		t.Errorf("unexpected error message: %q", errResp["error"])
+	}
+
+	close(blockCh)
+	wg.Wait()
+}
+
+func TestTrace_MetricsSuccess(t *testing.T) {
+	m := newTestMetrics(t)
+	h := newTraceHandler(traceSuccessRunner, m, defaultTraceConfig())
+	w := doTraceRequest(h, `{"code":"x=5"}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if v := getCounterValue(t, m.ExecutionsTotal, "success"); v != 1 {
+		t.Errorf("expected executions_total{status=success}=1, got %v", v)
+	}
+	if v := getGaugeValue(t, m.ActiveExecutions); v != 0 {
+		t.Errorf("expected active_executions=0, got %v", v)
+	}
+}
+
+func TestTrace_MetricsTimeout(t *testing.T) {
+	m := newTestMetrics(t)
+	h := newTraceHandler(timeoutRunner, m, defaultTraceConfig())
+	doTraceRequest(h, `{"code":"while True: pass"}`)
+
+	if v := getCounterValue(t, m.ExecutionsTotal, "timeout"); v != 1 {
+		t.Errorf("expected executions_total{status=timeout}=1, got %v", v)
+	}
+}
+
+func TestTrace_MetricsError(t *testing.T) {
+	m := newTestMetrics(t)
+	h := newTraceHandler(errorRunner, m, defaultTraceConfig())
+	doTraceRequest(h, `{"code":"x=1"}`)
+
+	if v := getCounterValue(t, m.ExecutionsTotal, "error"); v != 1 {
+		t.Errorf("expected executions_total{status=error}=1, got %v", v)
+	}
+}
+
+func TestTrace_MetricsValidationEmpty(t *testing.T) {
+	m := newTestMetrics(t)
+	h := newTraceHandler(traceSuccessRunner, m, defaultTraceConfig())
+	doTraceRequest(h, `{"code":""}`)
+
+	if v := getCounterValue(t, m.ValidationErrorsTotal, "invalid_request"); v != 1 {
+		t.Errorf("expected validation_errors_total{reason=invalid_request}=1, got %v", v)
+	}
+}
+
+func TestTrace_MetricsValidationCodeTooLarge(t *testing.T) {
+	m := newTestMetrics(t)
+	cfg := defaultTraceConfig()
+	cfg.MaxCodeBytes = 10
+	h := newTraceHandler(traceSuccessRunner, m, cfg)
+	doTraceRequest(h, fmt.Sprintf(`{"code":"%s"}`, strings.Repeat("x", 20)))
+
+	if v := getCounterValue(t, m.ValidationErrorsTotal, "code_too_large"); v != 1 {
+		t.Errorf("expected validation_errors_total{reason=code_too_large}=1, got %v", v)
+	}
+}

--- a/executor/internal/sandbox/sandbox.go
+++ b/executor/internal/sandbox/sandbox.go
@@ -40,6 +40,7 @@ type Request struct {
 	Files      []File
 	RandomSeed *int
 	TimeoutMs  int
+	Args       []string // Additional arguments passed to the Python script.
 }
 
 // File is an attached file available to the executed program.
@@ -135,6 +136,11 @@ func Run(ctx context.Context, cfg Config, req Request) (*Result, error) {
 		"--env", "PYTHONUNBUFFERED=1",
 		"--really_quiet",
 		"--", cfg.PythonPath, "/tmp/work/main.py",
+	}
+
+	// Append extra arguments after main.py (used by the tracer script).
+	if len(req.Args) > 0 {
+		args = append(args, req.Args...)
 	}
 
 	// Add /usr/lib64 bind mount if it exists (needed on some distros).

--- a/executor/internal/server/server.go
+++ b/executor/internal/server/server.go
@@ -3,7 +3,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -89,6 +88,25 @@ func NewWithRegistry(cfg *config.Config, logger *slog.Logger, reg prometheus.Reg
 	}
 	r.Post("/execute", executeHandler)
 
+	// Trace endpoint (shares rate limiter and concurrency pool concept with /execute).
+	traceHandler := handler.NewTraceHandler(
+		logger, sandbox.Run, m,
+		handler.TraceHandlerConfig{
+			NsjailPath:              cfg.NsjailPath,
+			PythonPath:              cfg.PythonPath,
+			MaxOutputBytes:          cfg.MaxOutputBytes,
+			MaxCodeBytes:            cfg.MaxCodeBytes,
+			MaxStdinBytes:           cfg.MaxStdinBytes,
+			MaxConcurrentExecutions: cfg.MaxConcurrentExecutions,
+		},
+	)
+	var traceHandlerFunc http.HandlerFunc = traceHandler.ServeHTTP
+	if cfg.RateLimitRPS > 0 {
+		limiter := rate.NewLimiter(rate.Limit(cfg.RateLimitRPS), cfg.RateLimitBurst)
+		traceHandlerFunc = rateLimitMiddleware(limiter, traceHandlerFunc)
+	}
+	r.Post("/trace", traceHandlerFunc)
+
 	return &Server{
 		httpServer: &http.Server{
 			Addr:    fmt.Sprintf(":%d", cfg.Port),
@@ -102,9 +120,7 @@ func NewWithRegistry(cfg *config.Config, logger *slog.Logger, reg prometheus.Reg
 
 // readyzHandler returns an HTTP handler that checks if nsjail and python3 binaries are accessible.
 func readyzHandler(cfg *config.Config, m *metrics.Metrics) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
+	return func(w http.ResponseWriter, _ *http.Request) {
 		components := map[string]string{}
 		healthy := true
 
@@ -123,16 +139,16 @@ func readyzHandler(cfg *config.Config, m *metrics.Metrics) http.HandlerFunc {
 		}
 
 		status := "ok"
+		code := http.StatusOK
 		if !healthy {
 			status = "unhealthy"
+			code = http.StatusServiceUnavailable
 			m.Ready.Set(0)
-			w.WriteHeader(http.StatusServiceUnavailable)
 		} else {
 			m.Ready.Set(1)
-			w.WriteHeader(http.StatusOK)
 		}
 
-		_ = json.NewEncoder(w).Encode(readyResponse{
+		httputil.WriteJSON(w, code, readyResponse{
 			Status:     status,
 			Components: components,
 		})

--- a/executor/internal/server/server_test.go
+++ b/executor/internal/server/server_test.go
@@ -135,6 +135,20 @@ func TestExecuteRoute(t *testing.T) {
 	}
 }
 
+func TestTraceRoute(t *testing.T) {
+	srv := newTestServer(t)
+
+	// POST with no body should get 400 (invalid JSON), proving the route is wired.
+	req := httptest.NewRequest(http.MethodPost, "/trace", nil)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
 func TestMetrics(t *testing.T) {
 	srv := newTestServer(t)
 
@@ -210,12 +224,12 @@ func TestRateLimitMiddleware_Rejects(t *testing.T) {
 		t.Errorf("second request: status = %d, want %d", rec2.Code, http.StatusTooManyRequests)
 	}
 
-	var resp map[string]string
-	if err := json.NewDecoder(rec2.Body).Decode(&resp); err != nil {
+	var errResp map[string]string
+	if err := json.NewDecoder(rec2.Body).Decode(&errResp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if resp["error"] != "rate limit exceeded" {
-		t.Errorf("error = %q, want %q", resp["error"], "rate limit exceeded")
+	if errResp["error"] != "rate limit exceeded" {
+		t.Errorf("error = %q, want %q", errResp["error"], "rate limit exceeded")
 	}
 
 	if called != 1 {

--- a/executor/internal/tracer/script.py
+++ b/executor/internal/tracer/script.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Python execution tracer for debugging support.
+Captures execution steps, variable states, and call stack.
+
+Output keys use snake_case to match the Go/frontend JSON wire format.
+"""
+
+import sys
+import json
+import traceback
+import io
+from contextlib import redirect_stdout
+
+# Configuration
+MAX_STEPS = 5000
+MAX_VAR_LENGTH = 1000
+
+
+class ExecutionTracer:
+    def __init__(self, max_steps=MAX_STEPS):
+        self.steps = []
+        self.step_count = 0
+        self.max_steps = max_steps
+        self.truncated = False
+        self.stdout_buffer = io.StringIO()
+        self.call_stack = []
+
+    def format_value(self, value):
+        """Format a value for JSON serialization with truncation."""
+        try:
+            if value is None:
+                return None
+            elif isinstance(value, (bool, int, float)):
+                return value
+            elif isinstance(value, str):
+                if len(value) > MAX_VAR_LENGTH:
+                    return value[:MAX_VAR_LENGTH] + '...'
+                return value
+            elif isinstance(value, (list, tuple)):
+                if len(value) > 10:
+                    formatted = [self.format_value(v) for v in value[:10]]
+                    return formatted + ['...']
+                return [self.format_value(v) for v in value]
+            elif isinstance(value, dict):
+                if len(value) > 10:
+                    items = list(value.items())[:10]
+                    result = {str(k): self.format_value(v) for k, v in items}
+                    result['...'] = '...'
+                    return result
+                return {str(k): self.format_value(v) for k, v in value.items()}
+            elif callable(value):
+                return f'<function {getattr(value, "__name__", "?")}>'
+            else:
+                s = str(value)
+                if len(s) > MAX_VAR_LENGTH:
+                    s = s[:MAX_VAR_LENGTH] + '...'
+                return f'<{type(value).__name__}: {s}>'
+        except:
+            return '<unserializable>'
+
+    def get_variables(self, frame):
+        """Extract and format local and global variables."""
+        # Get locals (filter out internal variables)
+        locals_dict = {}
+        for name, value in frame.f_locals.items():
+            if not name.startswith('__'):
+                locals_dict[name] = self.format_value(value)
+
+        # Get globals (only user-defined functions and variables)
+        globals_dict = {}
+        for name, value in frame.f_globals.items():
+            if not name.startswith('__') and name not in ['sys', 'json', 'io', 'traceback', 'ExecutionTracer']:
+                globals_dict[name] = self.format_value(value)
+
+        return locals_dict, globals_dict
+
+    def get_call_stack(self, frame):
+        """Build call stack from current frame."""
+        stack = []
+        current = frame
+        while current is not None:
+            func_name = current.f_code.co_name
+            filename = current.f_code.co_filename
+            line = current.f_lineno
+
+            # Only include user code (not tracer internals)
+            if filename == '<string>':
+                stack.append({
+                    'function_name': func_name,
+                    'filename': filename,
+                    'line': line
+                })
+
+            current = current.f_back
+
+        return list(reversed(stack))
+
+    def trace_function(self, frame, event, arg):
+        """Trace function called on each line execution."""
+        # Check step limit
+        if self.step_count >= self.max_steps:
+            self.truncated = True
+            return None  # Stop tracing
+
+        # Only trace user code (not libraries or tracer itself)
+        filename = frame.f_code.co_filename
+        if filename != '<string>':
+            return self.trace_function
+
+        # Capture step
+        locals_dict, globals_dict = self.get_variables(frame)
+        call_stack = self.get_call_stack(frame)
+
+        step = {
+            'line': frame.f_lineno,
+            'event': event,
+            'locals': locals_dict,
+            'globals': globals_dict,
+            'call_stack': call_stack,
+            'stdout': self.stdout_buffer.getvalue()
+        }
+
+        self.steps.append(step)
+        self.step_count += 1
+
+        return self.trace_function
+
+    def execute(self, code, stdin_data=''):
+        """Execute code with tracing enabled."""
+        # Set up stdin
+        if stdin_data:
+            sys.stdin = io.StringIO(stdin_data)
+
+        # Redirect stdout
+        original_stdout = sys.stdout
+        sys.stdout = self.stdout_buffer
+
+        exit_code = 0
+        error = None
+
+        try:
+            # Set up tracing
+            sys.settrace(self.trace_function)
+
+            # Execute code
+            exec(code, {'__name__': '__main__'})
+
+        except Exception as e:
+            exit_code = 1
+            error = f"{type(e).__name__}: {str(e)}\n{traceback.format_exc()}"
+        finally:
+            # Restore
+            sys.settrace(None)
+            sys.stdout = original_stdout
+            if stdin_data:
+                sys.stdin = sys.__stdin__
+
+        return {
+            'steps': self.steps,
+            'total_steps': self.step_count,
+            'exit_code': exit_code,
+            'error': error,
+            'truncated': self.truncated
+        }
+
+
+def main():
+    """Main entry point - read code and execute with tracing."""
+    if len(sys.argv) < 2:
+        print(json.dumps({'error': 'No code provided'}))
+        sys.exit(1)
+
+    code = sys.argv[1]
+    stdin_data = sys.argv[2] if len(sys.argv) > 2 else ''
+    max_steps = int(sys.argv[3]) if len(sys.argv) > 3 else MAX_STEPS
+
+    tracer = ExecutionTracer(max_steps=max_steps)
+    result = tracer.execute(code, stdin_data)
+
+    # Output as JSON
+    print(json.dumps(result))
+
+
+if __name__ == '__main__':
+    main()

--- a/executor/internal/tracer/tracer.go
+++ b/executor/internal/tracer/tracer.go
@@ -1,0 +1,10 @@
+// Package tracer provides the embedded Python tracer script for step-through debugging.
+package tracer
+
+import _ "embed"
+
+// Script is the Python tracer that uses sys.settrace() to capture execution steps.
+// It is written to a temp file and executed inside the nsjail sandbox.
+//
+//go:embed script.py
+var Script string

--- a/go-backend/internal/executor/client.go
+++ b/go-backend/internal/executor/client.go
@@ -83,22 +83,17 @@ func (c *Client) Execute(ctx context.Context, req ExecuteRequest) (*ExecuteRespo
 	return &resp, nil
 }
 
-// TraceStep represents a single step in a debugger trace.
-type TraceStep struct {
-	Line      int               `json:"line"`
-	Variables map[string]string `json:"variables"`
-	Output    string            `json:"output,omitempty"`
-}
+// TraceRequest is an alias for the shared trace request type.
+type TraceRequest = executorapi.TraceRequest
 
-// TraceRequest is the request for a debugger trace.
-type TraceRequest struct {
-	Code string `json:"code"`
-}
+// TraceResponse is an alias for the shared trace response type.
+type TraceResponse = executorapi.TraceResponse
 
-// TraceResponse is the response from the executor trace endpoint.
-type TraceResponse struct {
-	Steps []TraceStep `json:"steps"`
-}
+// TraceStep is an alias for the shared trace step type.
+type TraceStep = executorapi.TraceStep
+
+// CallFrame is an alias for the shared call frame type.
+type CallFrame = executorapi.CallFrame
 
 // Trace sends code to the executor service for step-through debugger tracing.
 func (c *Client) Trace(ctx context.Context, req TraceRequest) (*TraceResponse, error) {

--- a/go-backend/internal/handler/session_trace.go
+++ b/go-backend/internal/handler/session_trace.go
@@ -23,6 +23,8 @@ type TracerClient interface {
 type traceHTTPRequest struct {
 	StudentID *uuid.UUID `json:"student_id"` // optional; defaults to caller's own ID
 	Code      string     `json:"code" validate:"required"`
+	Stdin     string     `json:"stdin"`
+	MaxSteps  *int       `json:"max_steps,omitempty"`
 }
 
 // TraceHandler handles debugger trace requests for sessions.
@@ -86,7 +88,11 @@ func (h *TraceHandler) Trace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call executor trace
-	traceResp, err := h.tracer.Trace(r.Context(), executor.TraceRequest{Code: req.Code})
+	traceResp, err := h.tracer.Trace(r.Context(), executor.TraceRequest{
+		Code:     req.Code,
+		Stdin:    req.Stdin,
+		MaxSteps: req.MaxSteps,
+	})
 	if err != nil {
 		httputil.WriteError(w, http.StatusInternalServerError, "trace execution failed")
 		return

--- a/go-backend/internal/handler/session_trace_test.go
+++ b/go-backend/internal/handler/session_trace_test.go
@@ -69,9 +69,11 @@ func TestTrace_HappyPath(t *testing.T) {
 		traceFn: func(_ context.Context, req executor.TraceRequest) (*executor.TraceResponse, error) {
 			return &executor.TraceResponse{
 				Steps: []executor.TraceStep{
-					{Line: 1, Variables: map[string]string{"x": "5"}, Output: ""},
-					{Line: 2, Variables: map[string]string{"x": "5", "y": "10"}, Output: "15"},
+					{Line: 1, Event: "line", Locals: map[string]interface{}{"x": 5}, Globals: map[string]interface{}{}, Stdout: ""},
+					{Line: 2, Event: "line", Locals: map[string]interface{}{"x": 5, "y": 10}, Globals: map[string]interface{}{}, Stdout: "15"},
 				},
+				TotalSteps: 2,
+				ExitCode:   0,
 			}, nil
 		},
 	}
@@ -109,8 +111,10 @@ func TestTrace_200StudentParticipant(t *testing.T) {
 		traceFn: func(_ context.Context, req executor.TraceRequest) (*executor.TraceResponse, error) {
 			return &executor.TraceResponse{
 				Steps: []executor.TraceStep{
-					{Line: 1, Variables: map[string]string{"x": "1"}, Output: "1"},
+					{Line: 1, Event: "line", Locals: map[string]interface{}{"x": 1}, Globals: map[string]interface{}{}, Stdout: "1"},
 				},
+				TotalSteps: 1,
+				ExitCode:   0,
 			}, nil
 		},
 	}

--- a/pkg/executorapi/types.go
+++ b/pkg/executorapi/types.go
@@ -24,3 +24,36 @@ type ExecuteResponse struct {
 	ExecutionTimeMs int64  `json:"execution_time_ms"`
 	Stdin           string `json:"stdin,omitempty"`
 }
+
+// TraceRequest is the JSON request body for step-through debugger tracing.
+type TraceRequest struct {
+	Code     string `json:"code"`
+	Stdin    string `json:"stdin,omitempty"`
+	MaxSteps *int   `json:"max_steps,omitempty"`
+}
+
+// TraceResponse is the JSON response for debugger tracing.
+type TraceResponse struct {
+	Steps      []TraceStep `json:"steps"`
+	TotalSteps int         `json:"total_steps"`
+	ExitCode   int         `json:"exit_code"`
+	Error      string      `json:"error,omitempty"`
+	Truncated  bool        `json:"truncated,omitempty"`
+}
+
+// TraceStep represents a single step in a debugger trace.
+type TraceStep struct {
+	Line      int                    `json:"line"`
+	Event     string                 `json:"event"`
+	Locals    map[string]interface{} `json:"locals"`
+	Globals   map[string]interface{} `json:"globals"`
+	CallStack []CallFrame            `json:"call_stack"`
+	Stdout    string                 `json:"stdout"`
+}
+
+// CallFrame represents a single frame in the call stack.
+type CallFrame struct {
+	FunctionName string `json:"function_name"`
+	Filename     string `json:"filename"`
+	Line         int    `json:"line"`
+}


### PR DESCRIPTION
## Summary
- Implements the `/trace` endpoint in the executor service, porting the Python `sys.settrace()`-based tracer from the old Node backend
- Adds shared trace types to `pkg/executorapi` and `pkg/httputil` to eliminate code drift between services
- Updates the backend executor client and session trace handler to use the richer trace format expected by the frontend

## Changes
- **pkg/executorapi/types.go**: Add `TraceRequest`, `TraceResponse`, `TraceStep`, `CallFrame` types matching frontend wire format
- **pkg/httputil/**: New shared module with `WriteError`, `WriteJSON`, `Healthz` (replaces inline `writeError` in executor)
- **executor/internal/tracer/**: Embedded Python tracer script using `sys.settrace()` — captures line, event, locals, globals, call_stack, stdout per step
- **executor/internal/handler/trace.go**: New handler with validation, concurrency limiting, metrics, JSON parsing of tracer output
- **executor/internal/sandbox/sandbox.go**: Add `Args` field to `Request` for passing arguments to Python scripts
- **executor/internal/server/server.go**: Register `POST /trace` route with rate limiting
- **go-backend/internal/executor/client.go**: Replace local trace types with shared `executorapi` aliases
- **go-backend/internal/handler/session_trace.go**: Forward `stdin` and `max_steps` to executor

## Test plan
- [x] 21 new trace handler unit tests (success, multi-step, error, truncated, timeout, validation, concurrency, metrics)
- [x] Route wiring test for `/trace`
- [x] All existing execute handler tests pass with `httputil` migration
- [x] Backend session_trace tests updated and passing
- [x] `make test-executor`, `make lint-executor`, `make test-api`, `make lint-api`, `make typecheck-frontend` all pass

Beads: PLAT-3ez

Generated with Claude Code