### PR TITLE
chore: protect main branch, remove direct mode

### DIFF
--- a/.claude/commands/gh-issue.md
+++ b/.claude/commands/gh-issue.md
@@ -20,7 +20,7 @@ Use priority 1 for bugs, 2 for features/tasks unless the issue indicates urgency
 
 ## 3. Implement
 
-Follow the coordinator workflow below. The coordinator will triage the work and decide whether to execute directly or create a branch/PR.
+Follow the coordinator workflow below. The coordinator will triage the work and create a branch/PR.
 
 ## 4. PR Must Reference the GitHub Issue
 

--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: coordinator
-description: Single entry point for all implementation work. Triages tasks, manages beads issues, decides direct vs. branch execution, delegates to implementer skill, runs reviewers, creates PRs.
+description: Single entry point for all implementation work. Triages tasks, manages beads issues, delegates to implementer skill, runs reviewers, creates PRs.
 ---
 
 # Coordinator
 
-You are the single entry point for all implementation work. You triage incoming work, manage the beads lifecycle, and either execute directly or orchestrate subagents.
+You are the single entry point for all implementation work. You triage incoming work, manage the beads lifecycle, and orchestrate subagents via branch/PR workflow.
+
+**IMPORTANT:** The main branch is protected. All changes MUST go through a feature branch and PR. Direct commits to main are not allowed.
 
 ## Phase 1: Triage
 
@@ -29,74 +31,11 @@ Create a beads issue first:
 bd create "<description>" -t <task|bug|feature> -p 2 --json
 ```
 
-### 2. Choose Execution Mode
-
-| Condition | Mode |
-|-----------|------|
-| Small, focused change (1-3 files, single concern) | **Direct** |
-| Multiple related issues being worked together | **Branch** |
-| Cross-cutting change (5+ files, multiple concerns) | **Branch** |
-| Epic or has subtasks | **Branch** |
-| Removal/refactor of a feature | **Branch** |
-| User explicitly requests PR | **Branch** |
-
----
-
-## Direct Mode
-
-For single tasks. Work in the main checkout, commit to main, no PR.
-
-### 1. Claim
-
-```bash
-bd update <id> --status in_progress --json
-```
-
-### 2. Develop
-
-Follow the implementer skill phases:
-
-@.claude/skills/implementer/SKILL.md
-
-### 3. Commit and Push
-
-```bash
-git add -A
-git commit -m "$(cat <<'EOF'
-<type>: <description>
-
-<optional body>
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-EOF
-)"
-git pull --rebase
-bd sync
-git push
-```
-
-Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
-
-**Gate:** `git push` succeeds. If push fails, resolve and retry. Work is not complete until pushed.
-
-### 4. Close
-
-```bash
-bd close <id> --reason "Completed" --json
-```
-
-File issues for any remaining or discovered work:
-```bash
-bd create "Remaining work description" -t task -p 2 --json
-```
-
-Summarize what was done and note any follow-up tasks created.
-
 ---
 
 ## Branch Mode
 
-For epics, multi-task work, or when a PR is needed. Uses worktrees and subagents.
+All work uses branches and PRs. Uses worktrees and subagents.
 
 ### 1. Setup
 
@@ -276,6 +215,7 @@ EOF
 
 ## Anti-Patterns
 
+- Committing directly to main (branch is protected — all changes require a PR)
 - Starting dependent task before blocker is closed
 - Parallelizing tasks that touch same files
 - Creating PR before running specialized reviews

--- a/.claude/skills/implementer/SKILL.md
+++ b/.claude/skills/implementer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementer
-description: Pure development workflow with test-first development and coverage review. Used by coordinator directly or as a subagent. Never manages beads issues or commits.
+description: Pure development workflow with test-first development and coverage review. Used by coordinator as a subagent. Never manages beads issues or commits.
 ---
 
 # Implementer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ for resolving larger issues in follow-on work.
 
 `/plan` explores the codebase, discusses tradeoffs with you, files beads issues, and runs an architectural plan review. Use it before `/work` for new epics.
 
-`/work` is the single entry point for all implementation. It triages the work, decides whether to commit directly to main or create a branch/PR, manages beads issues, and runs specialized reviews for branch work.
+`/work` is the single entry point for all implementation. It triages the work, creates a branch/PR, manages beads issues, and runs specialized reviews.
 
 `/merge` processes open PRs: merges when CI passes, handles rebases, files issues for failures. Run in a dedicated window while other windows do `/work`.
 


### PR DESCRIPTION
## Summary
- Enabled GitHub branch protection on `main` (PRs required, direct pushes blocked)
- Removed the entire "Direct Mode" workflow from the coordinator skill
- Updated all skill/command descriptions to reflect branch-only workflow

## Changes
- `.claude/skills/coordinator/SKILL.md` — removed Direct Mode section, decision table, and commit-to-main workflow. Added anti-pattern for direct commits. Updated description.
- `AGENTS.md` — updated `/work` description to remove "decides whether to commit directly to main"
- `.claude/commands/gh-issue.md` — updated to say coordinator creates branch/PR (not "decide whether to execute directly")
- `.claude/skills/implementer/SKILL.md` — updated description from "directly or as a subagent" to "as a subagent"

## Test plan
- [x] Verify `gh api repos/jdelfino/eval/branches/main/protection` shows required_pull_request_reviews enabled
- [x] Verify coordinator skill no longer mentions direct mode
- [x] Verify no remaining references to "commit directly to main" in skill files

Generated with Claude Code