### PR TITLE
chore: parallelize e2e CI setup steps

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -155,8 +155,10 @@ jobs:
           fi
 
           # --- Wait for background jobs ---
-          wait $GO_PID || { echo "::error::Go build failed"; exit 1; }
-          wait $EXEC_PID || { echo "::error::Executor setup failed"; exit 1; }
+          FAILED=false
+          wait $GO_PID || { echo "::error::Go build failed"; FAILED=true; }
+          wait $EXEC_PID || { echo "::error::Executor setup failed"; FAILED=true; }
+          if [ "$FAILED" = "true" ]; then exit 1; fi
 
       - name: Run E2E tests
         run: make test-e2e


### PR DESCRIPTION
## Summary
- Run Go build and executor setup as background shell processes while npm ci + Playwright install run in the foreground
- Move GCP auth and executor-changed check earlier in the step sequence so their outputs are available for the parallel step
- Expected ~45% reduction in setup wall-clock time (~100s savings)

## Changes
- `.github/workflows/e2e-tests.yml` — combined 8 sequential setup steps into a single parallel step using shell job control (`&` + `wait`)

## Test plan
- [ ] Verify workflow runs successfully on this PR (will trigger since it changes a workflow file path... actually it only triggers on go-backend/frontend/executor/pkg/migrations/scripts changes, so will need manual trigger)
- [ ] Check CI logs show parallel execution (interleaved `[executor]` and npm/Playwright output)
- [ ] Verify executor container is healthy before tests run

Beads: PLAT-t3a1

Generated with Claude Code