### PR TITLE
fix: handle nested standalone output in E2E script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,9 @@ executor/tmp/
 
 # Auto-generated Next.js type declarations
 frontend/next-env.d.ts
+
+# Root-level lock files (projects have their own; a stray root lock file
+# causes Next.js Turbopack to mis-infer the workspace root)
+/package-lock.json
+/yarn.lock
+/pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- E2E script now detects both flat and nested standalone output structures from Next.js 16 Turbopack
- Root-level lock files (package-lock.json, yarn.lock, pnpm-lock.yaml) are gitignored to prevent Turbopack workspace root mis-detection

## Changes
- `scripts/run-e2e-tests.sh`: Probe for `server.js` at both `standalone/` and `standalone/frontend/` before copying static assets and starting the server. Clear error message with directory listing if neither is found.
- `.gitignore`: Ignore root-level lock files that cause Next.js Turbopack to infer the wrong workspace root.

## Root cause
PR #57 introduced a stray root-level `package-lock.json` (6 lines, empty packages). Next.js 16 Turbopack uses this to infer the workspace root as the repo root rather than `frontend/`, causing standalone output to be placed at `.next/standalone/frontend/` instead of `.next/standalone/`. The `cp` command in the E2E script expected the flat structure and failed.

## Test plan
- [ ] E2E tests pass on this PR (validates the flat-structure path still works)
- [ ] After merging, rebase PR #57 onto main — the nested-structure path will also be handled

Beads: PLAT-pn4u

Generated with Claude Code