### PR TITLE
fix: set executor minReplicaCount to 1 until scale-to-zero is fixed

### DIFF
--- a/k8s/base/executor-scaledobject.yaml
+++ b/k8s/base/executor-scaledobject.yaml
@@ -5,18 +5,17 @@ metadata:
 spec:
   scaleTargetRef:
     name: executor
-  minReplicaCount: 0
+  # Keep 1 replica running. Scale-to-zero requires a GMP query frontend
+  # (not yet deployed) and a scale-from-zero trigger. See PLAT-y2nz.
+  minReplicaCount: 1
   maxReplicaCount: 10
   cooldownPeriod: 60
   pollingInterval: 15
   triggers:
     - type: prometheus
       metadata:
-        # GKE Managed Prometheus (GMP) exposes a Prometheus-compatible query
-        # frontend in the gmp-system namespace. The previous address
-        # (prometheus-server.monitoring) pointed to a non-existent self-hosted
-        # Prometheus, causing KEDA to never receive metric data and leaving the
-        # executor deployment stuck at its initial replica count.
+        # GMP query frontend (frontend.gmp-system.svc:9090) is not yet deployed.
+        # Once PLAT-y2nz is resolved, update this address and set minReplicaCount: 0.
         serverAddress: http://frontend.gmp-system.svc:9090
         metricName: executor_active_executions
         query: sum(executor_active_executions)


### PR DESCRIPTION
## Summary
- Set KEDA ScaledObject `minReplicaCount: 1` (was 0) to avoid TriggerError from missing GMP frontend
- Adds comments referencing PLAT-y2nz for the full scale-to-zero fix

## Context
PR #67 fixed the ScaledObject serverAddress but the GMP query frontend (`frontend.gmp-system.svc:9090`) was never deployed, so KEDA can't query metrics. Additionally, scale-from-zero needs an external trigger since the metric is only emitted by executor pods. Keeping 1 replica running costs ~$11/mo (spot).

## Test plan
- [ ] Deploy and verify executor stays at 1 replica
- [ ] Verify KEDA stops logging TriggerError

Beads: PLAT-y2nz

Generated with Claude Code