### PR TITLE
fix: add private network tag to GKE nodes for NAT route targeting

### DIFF
--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -90,9 +90,10 @@ module "nat" {
   public_subnet_id    = module.vpc.public_subnet_id
   private_subnet_cidr = var.gke_subnet_cidr
 
-  # Apply NAT route to all instances (no tag filter). Cloud NAT previously
-  # covered all subnets; the NAT VM route must do the same for GKE private nodes.
-  route_tags = []
+  # Apply NAT route only to instances tagged "private". The GKE module applies
+  # this tag to all node pools. The NAT VM itself must NOT match, or it creates
+  # a routing loop (it would try to route its own outbound traffic through itself).
+  route_tags = ["private"]
 }
 
 module "gke" {
@@ -125,6 +126,7 @@ module "gke" {
   executor_pool_max_nodes    = var.gke_executor_pool_max_nodes
   executor_pool_spot         = var.gke_executor_pool_spot
   executor_pool_disk_size_gb = var.gke_executor_pool_disk_size_gb
+  node_network_tags          = ["private"]
 }
 
 module "cloudsql" {

--- a/infrastructure/terraform/modules/gke/main.tf
+++ b/infrastructure/terraform/modules/gke/main.tf
@@ -130,6 +130,7 @@ resource "google_container_node_pool" "default" {
     machine_type = var.default_pool_machine_type
     spot         = var.default_pool_spot
     disk_size_gb = var.default_pool_disk_size_gb
+    tags         = var.node_network_tags
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
@@ -164,6 +165,7 @@ resource "google_container_node_pool" "executor" {
     image_type   = "COS_CONTAINERD"
     spot         = var.executor_pool_spot
     disk_size_gb = var.executor_pool_disk_size_gb
+    tags         = var.node_network_tags
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 

--- a/infrastructure/terraform/modules/gke/variables.tf
+++ b/infrastructure/terraform/modules/gke/variables.tf
@@ -149,6 +149,16 @@ variable "cluster_resource_labels" {
 }
 
 # -----------------------------------------------------------------------------
+# Network Tags
+# -----------------------------------------------------------------------------
+
+variable "node_network_tags" {
+  description = "Network tags applied to all node pool instances (used for route targeting)"
+  type        = list(string)
+  default     = []
+}
+
+# -----------------------------------------------------------------------------
 # Default Node Pool
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- The `route_tags=[]` change from PR #67 applied the NAT VM route to ALL instances including the NAT VM itself, creating a **routing loop** that broke internet access for the entire VPC
- GMP pods, image pulls, and all outbound traffic are failing with `i/o timeout`
- **Production is currently down** because nodes can't pull container images

## Root Cause

The NAT route (priority 800) with no tags takes precedence over the default internet gateway route (priority 1000) for all instances. The NAT VM routes its own outbound traffic through itself instead of the default gateway.

## Fix

- Add `node_network_tags` variable to GKE module
- Tag both node pools with `"private"`
- Set NAT `route_tags = ["private"]` so only GKE nodes use the NAT route
- NAT VM (tagged `"nat-gateway"`) correctly uses the default internet gateway

## What Happens on Apply

- GKE node pools get the `"private"` network tag (node pool update, may cause rolling restart)
- NAT route updated to target only `"private"` tagged instances (fixes the routing loop immediately)

## Test plan

- [ ] `terraform plan` shows tag additions and route update
- [ ] `terraform apply` restores internet access
- [ ] GMP pods recover from ImagePullBackOff
- [ ] Re-trigger deploy pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)