### PR TITLE
fix: route instructors to session dashboard instead of student workspace

### DIFF
--- a/frontend/src/app/(app)/sections/[section_id]/__tests__/page.test.tsx
+++ b/frontend/src/app/(app)/sections/[section_id]/__tests__/page.test.tsx
@@ -4,7 +4,9 @@
  * Tests:
  * - Role-aware back button navigation (instructor vs student)
  * - Error-state back button fallbacks
- * - Past session view button routes by role
+ * - Active session button routes by role (instructor/admin -> instructor dashboard, student -> student workspace)
+ * - Active session button label by role ("View Dashboard" for instructors, "Join Now" for students)
+ * - Past session view button routes by role (including namespace-admin and system-admin)
  * - Past session metadata display
  */
 
@@ -41,6 +43,22 @@ jest.mock('@/lib/api/classes', () => ({
 const mockPush = jest.fn();
 const CLASS_ID = 'class-abc-123';
 const SECTION_ID = 'section-xyz-789';
+
+const activeSession = {
+  id: 'session-active-1',
+  namespace_id: 'ns-1',
+  section_id: SECTION_ID,
+  section_name: 'Section A',
+  status: 'active',
+  created_at: '2026-02-20T10:00:00Z',
+  last_activity: '2026-02-20T10:30:00Z',
+  ended_at: null,
+  problem: { title: 'Active Problem', description: 'An active problem' },
+  participants: ['student-1'],
+  featured_student_id: null,
+  featured_code: null,
+  creator_id: 'user-1',
+};
 
 const pastSession = {
   id: 'session-past-1',
@@ -192,9 +210,103 @@ describe('SectionDetailPage', () => {
     });
   });
 
+  describe('active session navigation', () => {
+    it('routes instructors to instructor dashboard when clicking active session button', async () => {
+      mockUser('instructor');
+      mockSectionData([activeSession]);
+
+      render(<SectionDetailPage />);
+
+      const btn = await screen.findByRole('button', { name: /View Dashboard/i });
+      await userEvent.click(btn);
+
+      expect(mockPush).toHaveBeenCalledWith('/instructor/session/session-active-1');
+    });
+
+    it('routes namespace-admins to instructor dashboard when clicking active session button', async () => {
+      mockUser('namespace-admin');
+      mockSectionData([activeSession]);
+
+      render(<SectionDetailPage />);
+
+      const btn = await screen.findByRole('button', { name: /View Dashboard/i });
+      await userEvent.click(btn);
+
+      expect(mockPush).toHaveBeenCalledWith('/instructor/session/session-active-1');
+    });
+
+    it('routes system-admins to instructor dashboard when clicking active session button', async () => {
+      mockUser('system-admin');
+      mockSectionData([activeSession]);
+
+      render(<SectionDetailPage />);
+
+      const btn = await screen.findByRole('button', { name: /View Dashboard/i });
+      await userEvent.click(btn);
+
+      expect(mockPush).toHaveBeenCalledWith('/instructor/session/session-active-1');
+    });
+
+    it('routes students to student workspace when clicking active session button', async () => {
+      mockUser('student');
+      mockSectionData([activeSession]);
+
+      render(<SectionDetailPage />);
+
+      const btn = await screen.findByRole('button', { name: /Join Now/i });
+      await userEvent.click(btn);
+
+      expect(mockPush).toHaveBeenCalledWith('/student?session_id=session-active-1');
+    });
+
+    it('shows "View Dashboard" label for instructors on active sessions', async () => {
+      mockUser('instructor');
+      mockSectionData([activeSession]);
+
+      render(<SectionDetailPage />);
+
+      expect(await screen.findByText('View Dashboard')).toBeInTheDocument();
+      expect(screen.queryByText('Join Now')).not.toBeInTheDocument();
+    });
+
+    it('shows "Join Now" label for students on active sessions', async () => {
+      mockUser('student');
+      mockSectionData([activeSession]);
+
+      render(<SectionDetailPage />);
+
+      expect(await screen.findByText('Join Now')).toBeInTheDocument();
+      expect(screen.queryByText('View Dashboard')).not.toBeInTheDocument();
+    });
+  });
+
   describe('past session navigation', () => {
     it('shows View button that navigates instructors to instructor session view', async () => {
       mockUser('instructor');
+      mockSectionData([pastSession]);
+
+      render(<SectionDetailPage />);
+
+      const viewBtn = await screen.findByText('View');
+      await userEvent.click(viewBtn);
+
+      expect(mockPush).toHaveBeenCalledWith('/instructor/session/session-past-1');
+    });
+
+    it('shows View button that navigates namespace-admins to instructor session view', async () => {
+      mockUser('namespace-admin');
+      mockSectionData([pastSession]);
+
+      render(<SectionDetailPage />);
+
+      const viewBtn = await screen.findByText('View');
+      await userEvent.click(viewBtn);
+
+      expect(mockPush).toHaveBeenCalledWith('/instructor/session/session-past-1');
+    });
+
+    it('shows View button that navigates system-admins to instructor session view', async () => {
+      mockUser('system-admin');
       mockSectionData([pastSession]);
 
       render(<SectionDetailPage />);

--- a/frontend/src/app/(app)/sections/[section_id]/page.tsx
+++ b/frontend/src/app/(app)/sections/[section_id]/page.tsx
@@ -80,8 +80,14 @@ export default function SectionDetailPage() {
     }
   };
 
+  const isInstructor = user != null && ['instructor', 'namespace-admin', 'system-admin'].includes(user.role);
+
   const handleJoinSession = (session_id: string) => {
-    router.push(`/student?session_id=${session_id}`);
+    if (isInstructor) {
+      router.push(`/instructor/session/${session_id}`);
+    } else {
+      router.push(`/student?session_id=${session_id}`);
+    }
   };
 
   const formatDate = (dateString: string | Date) => {
@@ -102,8 +108,6 @@ export default function SectionDetailPage() {
       </div>
     );
   }
-
-  const isInstructor = user != null && ['instructor', 'namespace-admin', 'system-admin'].includes(user.role);
 
   if (error || !section) {
     return (
@@ -204,7 +208,7 @@ export default function SectionDetailPage() {
                         <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
                         </svg>
-                        Join Now
+                        {isInstructor ? 'View Dashboard' : 'Join Now'}
                       </button>
                     </div>
                   </div>
@@ -275,7 +279,7 @@ export default function SectionDetailPage() {
                       </div>
                       <button
                         onClick={() => router.push(
-                          section.role === 'instructor'
+                          isInstructor
                             ? `/instructor/session/${session.id}`
                             : `/student?session_id=${session.id}`
                         )}


### PR DESCRIPTION
## Summary
- Fix active session "Join Now" button on section detail page to route instructors/namespace-admins/system-admins to `/instructor/session/{id}` instead of `/student?session_id={id}`
- Fix past session "View" button to use `isInstructor` check instead of `section.role === 'instructor'`, which failed for namespace-admin and system-admin roles
- Show "View Dashboard" button label for teaching roles, "Join Now" for students

## Changes
- `frontend/src/app/(app)/sections/[section_id]/page.tsx` — moved `isInstructor` computation earlier, updated `handleJoinSession` to be role-aware, fixed past session routing condition, updated button label
- `frontend/src/app/(app)/sections/[section_id]/__tests__/page.test.tsx` — added 8 tests covering active/past session routing and button labels for all roles

## Test plan
- [x] All 2048 frontend tests pass
- [x] Lint clean (0 errors)
- [x] Typecheck clean

Beads: PLAT-z1ip, PLAT-i509

Generated with Claude Code