### PR TITLE
fix: make ExecutionResult output and error optional (omitempty)

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -213,8 +213,8 @@ export interface PublicProblem {
 
 export interface ExecutionResult {
   success: boolean;
-  output: string;
-  error: string;
+  output?: string;
+  error?: string;
   execution_time_ms: number;
   stdin?: string;
 }


### PR DESCRIPTION
## Summary
- Make `output` and `error` fields optional in the `ExecutionResult` TypeScript interface to match the Go backend's `omitempty` JSON tags
- When the backend omits these fields, they are `undefined` at runtime — the type now reflects this

## Changes
- `frontend/src/types/api.ts`: Changed `output: string` → `output?: string` and `error: string` → `error?: string`

## Test plan
- [x] TypeScript typecheck passes (`make typecheck-frontend`)
- [x] All 2048 frontend unit tests pass (`make test-frontend`)
- [x] Lint passes (`make lint-frontend`)
- [x] API import boundary check passes (`make check-api-imports`)
- [x] All existing usages of `.output` and `.error` already guard against undefined

Beads: PLAT-3d2b

Generated with Claude Code