### PR TITLE
chore: add CI test timeouts and make test-all

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -28,7 +28,7 @@ jobs:
         run: go build ./...
         working-directory: go-backend
       - name: Test
-        run: go test -v -race ./...
+        run: go test -v -race -timeout 5m ./...
         working-directory: go-backend
 
   lint:
@@ -54,6 +54,7 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -73,7 +74,7 @@ jobs:
           CENTRIFUGO_URL: http://localhost:8000
           CENTRIFUGO_API_KEY: local-api-key
           CENTRIFUGO_TOKEN_SECRET: local-dev-secret-key-not-for-production
-        run: go test -v -race ./...
+        run: go test -v -race -timeout 5m ./...
         working-directory: go-backend
       - name: Stop dependencies
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ frontend/next-env.d.ts
 /package-lock.json
 /yarn.lock
 /pnpm-lock.yaml
+.deps-ready

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ make reset-db            # Destroy and recreate DB with seed data
 make build               # Build all binaries
 make test                # Run all unit tests (with race detector)
 make test-integration    # Run all integration tests
+make test-all            # Unit + integration tests in parallel
 make lint                # Lint all projects
 make docker-build        # Build all Docker images
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,31 @@
 # ──────────────────────────────────────────────
 # Aggregate targets
 # ──────────────────────────────────────────────
-.PHONY: build test test-integration lint docker-build test-e2e
+.PHONY: build test test-integration lint docker-build test-e2e test-all ensure-test-deps
 
 build: build-api build-executor build-frontend
 test: test-api test-executor test-frontend
 test-integration: test-integration-store test-integration-realtime test-integration-api test-integration-executor test-integration-contract
 lint: lint-api lint-executor lint-frontend
+
+# Run all unit + integration tests. Use: make -j2 test-all
+# ensure-test-deps runs first (order-only prerequisite), then test targets run in parallel.
+
+# Force re-run if postgres isn't responding, even if stamp file is current
+ifneq ($(shell pg_isready -h localhost -p 5432 -q 2>/dev/null && echo yes),yes)
+.PHONY: .deps-ready
+endif
+
+.deps-ready: $(wildcard migrations/*.up.sql) docker-compose.yml
+	./scripts/ensure-test-postgres.sh
+	@touch $@
+
+ensure-test-deps: .deps-ready
+
+test-all: | ensure-test-deps
+test-all: test-api test-executor test-frontend \
+	test-integration-store test-integration-realtime test-integration-api \
+	test-integration-contract
 
 docker-build: docker-build-api docker-build-executor
 


### PR DESCRIPTION
## Summary
- Add `-timeout 5m` to `go test` in unit and integration CI jobs — on hang, Go panics with goroutine stack dumps showing where it's stuck
- Add `timeout-minutes: 10` to integration-test job as a safety net to kill the whole job
- Add `make test-all` target for parallel local testing (`make -j2 test-all`)
- Smart deps: stamp file tracks migration changes, `pg_isready` forces re-run if postgres is down

Prompted by the integration-test job hanging for 35+ minutes on PR #79.

## Test plan
- [ ] CI passes on this PR (the timeout changes apply to the workflow itself)
- [ ] `make -j2 test-all` runs unit + integration tests locally in parallel
- [ ] Re-running `make test-all` without changes skips `ensure-test-deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)