### PR TITLE
fix: use proper Button variants for problem card actions

### DIFF
--- a/frontend/src/app/(app)/instructor/components/CopyLinkDropdown.tsx
+++ b/frontend/src/app/(app)/instructor/components/CopyLinkDropdown.tsx
@@ -106,14 +106,14 @@ export function CopyLinkDropdown({ problem_id, class_id }: CopyLinkDropdownProps
     <div className="relative inline-flex" ref={ref}>
       <button
         onClick={copyGenericLink}
-        className="px-3 py-1.5 text-sm font-semibold text-gray-700 hover:bg-gray-100 rounded-l-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+        className="px-3 py-1.5 text-sm font-semibold text-gray-700 bg-white border border-gray-300 border-r-0 hover:bg-gray-50 rounded-l-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
         aria-label="Copy Link"
       >
         {copied ? 'Copied!' : 'Copy Link'}
       </button>
       <button
         onClick={openDropdown}
-        className="px-1.5 py-1.5 text-sm text-gray-700 hover:bg-gray-100 rounded-r-lg border-l border-gray-300 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+        className="px-1.5 py-1.5 text-sm text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-r-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
         aria-label="Show sections"
         aria-expanded={isOpen}
         aria-haspopup="true"

--- a/frontend/src/app/(app)/instructor/components/ProblemCard.tsx
+++ b/frontend/src/app/(app)/instructor/components/ProblemCard.tsx
@@ -103,19 +103,19 @@ export default function ProblemCard({
           </div>
 
           <div className="flex items-center gap-2">
-            <Button variant="ghost" size="sm" onClick={() => onEdit(problem.id)} title="Edit problem">
+            <Button variant="secondary" size="sm" onClick={() => onEdit(problem.id)} title="Edit problem">
               Edit
             </Button>
             <CopyLinkDropdown problem_id={problem.id} class_id={problem.class_id} />
             {onPublish && (
-              <Button variant="ghost" size="sm" onClick={() => onPublish(problem.id)} title="Publish to sections">
+              <Button variant="secondary" size="sm" onClick={() => onPublish(problem.id)} title="Publish to sections">
                 Publish
               </Button>
             )}
-            <Button variant="secondary" size="sm" onClick={() => onCreateSession(problem.id)} title="Create session">
+            <Button variant="primary" size="sm" onClick={() => onCreateSession(problem.id)} title="Create session">
               Create Session
             </Button>
-            <Button variant="ghost" size="sm" onClick={handleDeleteClick} disabled={isDeleting} title="Delete problem">
+            <Button variant="danger" size="sm" onClick={handleDeleteClick} disabled={isDeleting} title="Delete problem">
               {isDeleting ? '...' : 'Delete'}
             </Button>
           </div>
@@ -153,19 +153,19 @@ export default function ProblemCard({
       </div>
 
       <div className="flex flex-col gap-2">
-        <Button variant="ghost" size="sm" className="w-full" onClick={() => onEdit(problem.id)}>
+        <Button variant="secondary" size="sm" className="w-full" onClick={() => onEdit(problem.id)}>
           Edit
         </Button>
         <CopyLinkDropdown problem_id={problem.id} class_id={problem.class_id} />
         {onPublish && (
-          <Button variant="ghost" size="sm" className="w-full" onClick={() => onPublish(problem.id)}>
+          <Button variant="secondary" size="sm" className="w-full" onClick={() => onPublish(problem.id)}>
             Publish
           </Button>
         )}
-        <Button variant="secondary" size="sm" className="w-full" onClick={() => onCreateSession(problem.id)}>
+        <Button variant="primary" size="sm" className="w-full" onClick={() => onCreateSession(problem.id)}>
           Create Session
         </Button>
-        <Button variant="ghost" size="sm" className="w-full" onClick={handleDeleteClick} disabled={isDeleting}>
+        <Button variant="danger" size="sm" className="w-full" onClick={handleDeleteClick} disabled={isDeleting}>
           {isDeleting ? 'Deleting...' : 'Delete'}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- Fix ghost variant buttons appearing unstyled (transparent bg, gray text looked broken)
- Use semantic Button variants: secondary for standard actions, primary for CTA, danger for delete

## Changes
- `ProblemCard.tsx`: Edit/Publish → `secondary`, Create Session → `primary`, Delete → `danger`
- `CopyLinkDropdown.tsx`: Add border + white bg to match secondary button style

## Test plan
- [x] All 2130 frontend tests pass
- [ ] Visual check: buttons now have visible borders, colors, and clear hierarchy

Generated with Claude Code