### PR TITLE
chore: reduce implementer context window pressure

### DIFF
--- a/.claude/skills/implementer/SKILL.md
+++ b/.claude/skills/implementer/SKILL.md
@@ -29,7 +29,7 @@ Write tests for the behavior you are about to change or add. Do this **before** 
 
 1. Read the relevant production code to understand current behavior
 2. Write new test cases that describe the desired behavior after your change
-3. Run the tests using the appropriate `make test-*` target (see **Quality Gates** in CLAUDE.md)
+3. Verify your new tests fail by delegating to a sub-agent (same pattern as Phase 3 below)
 
 **Gate:** Your new tests **fail** (or, for pure deletions/removals, you can write tests asserting the old behavior is gone — these will pass after implementation). If your new tests already pass, they are not testing anything new. Rewrite them.
 
@@ -39,65 +39,37 @@ Make the production code changes. Keep changes minimal and focused on the task.
 
 ## Phase 3: Verify
 
-Run quality gates matching the code you changed. See the **Quality Gates** table in CLAUDE.md for all targets.
+Delegate quality gate runs to a sub-agent to preserve context. Use the Task tool with `subagent_type: "Bash"` and `model: "haiku"`:
 
-At minimum, for any Go backend change:
-```bash
-make test-api
-make lint-api
+```
+Run these commands sequentially in <worktree-path>:
+
+<commands from Quality Gates table in CLAUDE.md matching changed code>
+
+For example, for Go backend changes: make test-api && make lint-api
+For frontend changes: make test-frontend && make lint-frontend && make typecheck-frontend
+For store changes, also: make test-integration-store
+
+Report ONLY:
+- RESULT: PASS or FAIL
+- If FAIL: the specific error output (last 50 lines of the failing command)
+- Do NOT include passing test output
 ```
 
-For frontend changes:
-```bash
-make test-frontend
-make lint-frontend
-make typecheck-frontend
-```
+**Gate:** Sub-agent reports PASS. If FAIL, read the error output, fix the issue, and re-delegate. Only run quality gates directly in your own context if you need to debug a failure interactively.
 
-For store/persistence changes, also run:
-```bash
-make test-integration-store
-```
+## Phase 4: Test Coverage Audit
 
-**Gate:** All quality gate commands pass with zero errors. If any fails, fix the issues before proceeding.
+Evaluate whether your tests actually cover the changes you made. Do NOT re-read files you already have in context from writing them.
 
-## Phase 4: Test Coverage Review
+1. List changed files: `git diff --name-only`
+2. For each changed production file, evaluate from what you already know:
+   - What behavior changed? (new feature, bug fix, removed feature, refactored logic)
+   - Do your tests cover: happy path, error paths, edge cases, regressions?
+   - Are integration tests needed? (persistence, API routes, auth, cross-layer data flow)
+3. If gaps exist: write the missing tests, then re-run quality gates via sub-agent (same as Phase 3).
 
-This is an audit, not a formality. Evaluate whether your tests actually cover the changes you made.
-
-### Step 1: List what changed
-
-```bash
-git diff --name-only
-```
-
-Separate the output into production files and test files.
-
-### Step 2: For each changed production file, evaluate
-
-- **What behavior changed?** (new feature, bug fix, removed feature, refactored logic)
-- **What existing tests cover this file?** Read the corresponding test file if one exists.
-- **Are there gaps?** Specifically:
-  - Happy path for new/changed behavior
-  - Error paths and edge cases
-  - Regression test if this is a bug fix (a test that would have caught the original bug)
-  - Boundary conditions
-
-### Step 3: Evaluate integration test needs
-
-Integration tests are needed when changes affect:
-- Repository/persistence layer (database queries, data mapping)
-- API routes that combine multiple services
-- Auth flows or permission checks
-- Data flowing across multiple layers
-
-If integration tests are needed, write them.
-
-### Step 4: Fill gaps
-
-Write any missing tests identified above. Then re-run quality gates.
-
-**Gate:** All tests pass, including your new coverage additions. If you identified no gaps in Steps 2-3, document your reasoning (e.g., "Changes were purely deletions; added regression tests in Phase 1 confirming removed elements no longer render").
+**Gate:** No coverage gaps remain, or gaps are documented with reasoning (e.g., "Changes were purely deletions; added regression tests in Phase 1 confirming removed elements no longer render").
 
 ## Phase 5: Summary
 

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -68,10 +68,22 @@ After the user approves the plan:
 **Each subtask MUST be self-contained** (per AGENTS.md rules):
 - **Summary**: What and why in 1-2 sentences
 - **Files to modify**: Exact paths (with line numbers if relevant)
+- **Files to read for context**: Paths the implementer will need to understand before coding
 - **Implementation steps**: Numbered, specific actions
 - **Example**: Show before → after transformation when applicable
 
 A future implementer session must understand the task completely from its description alone — no external context.
+
+### Task Sizing
+
+Each subtask must fit within a single implementer context window without compaction. Use these heuristics:
+
+- **≤5 production files modified** per task
+- **≤10 files read for context** (including the files to modify, test files, shared types, referenced modules)
+- Prefer narrow vertical slices (one endpoint end-to-end) over horizontal layers (all endpoints at once)
+- When in doubt, split. Two small tasks are better than one that causes compaction.
+
+If "Files to read for context" exceeds ~10 entries, the task is probably too large — consider splitting it. But if splitting would create awkward boundaries or tightly coupled tasks, it's better to leave a large task whole.
 
 ### Phase 4 — Plan Review
 

--- a/.claude/skills/reviewer-plan/SKILL.md
+++ b/.claude/skills/reviewer-plan/SKILL.md
@@ -59,6 +59,12 @@ Read the code that will be affected. Understand:
 - [ ] Are there missing dependencies? (Task C uses types from task A but doesn't depend on it)
 - [ ] Is the dependency graph acyclic?
 
+#### Task Sizing (Context Budget)
+- [ ] Does each task modify ≤5 production files?
+- [ ] Does each task require reading ≤10 files for context (including files to modify)?
+- [ ] Are there "horizontal slice" tasks (e.g., "add all CRUD endpoints") that should be vertical slices?
+- If a task exceeds these limits, flag it as a concern. If splitting would create awkward boundaries or tightly coupled tasks, note that the task is large but accept it as-is.
+
 #### Scope & Completeness
 - [ ] Are tasks properly scoped? (Not too large for a single commit, not trivially small)
 - [ ] Are there missing tasks? (migrations, config, test infrastructure, shared utilities)


### PR DESCRIPTION
## Summary
- **Planner**: Add task sizing heuristics (≤5 files modified, ≤10 files read for context) and require "files to read for context" in subtask descriptions so oversized tasks are caught at planning time
- **Plan reviewer**: Add "Task Sizing (Context Budget)" checklist section — flags oversized tasks but accepts them when splitting would create awkward boundaries
- **Implementer**: Delegate quality gate runs (tests, lint, typecheck) to Bash sub-agents so passing output doesn't consume context. Happy path goes from ~200-600 lines of test output to a single "PASS"
- **Implementer**: Streamline coverage audit to evaluate from in-context knowledge instead of re-reading files just written

## Changes
- `.claude/skills/planner/SKILL.md` — added "Files to read for context" field and "Task Sizing" section to Phase 3
- `.claude/skills/reviewer-plan/SKILL.md` — added "Task Sizing (Context Budget)" checklist
- `.claude/skills/implementer/SKILL.md` — Phase 1 delegates test verification to sub-agent, Phase 3 rewired to use Bash sub-agents for quality gates, Phase 4 streamlined to avoid redundant file reads

## Test plan
- [ ] Run `/plan` on a non-trivial epic and verify the planner produces tasks with "files to read for context" and respects sizing heuristics
- [ ] Run `/work` on a task and verify the implementer delegates quality gates to sub-agents
- [ ] Verify plan reviewer flags an intentionally oversized task

Generated with Claude Code