### PR TITLE
feat: add invite token support to email sign-in page

### DIFF
--- a/frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx
+++ b/frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx
@@ -397,7 +397,7 @@ describe('EmailSignInPage', () => {
       expect(mockPush).not.toHaveBeenCalled();
     });
 
-    it('does NOT redirect to / when isAuthenticated becomes true (suppresses auto-redirect)', async () => {
+    it('does NOT redirect to / when isAuthenticated becomes true (suppresses auto-redirect)', () => {
       // When invite param is present, the isAuthenticated redirect should be suppressed
       // so that acceptInvite can run and redirect based on role instead.
       (useAuth as jest.Mock).mockReturnValue({
@@ -406,16 +406,31 @@ describe('EmailSignInPage', () => {
 
       render(<EmailSignInPage />);
 
-      // Wait a bit to confirm no redirect happened
-      await new Promise((resolve) => setTimeout(resolve, 100));
       expect(mockPush).not.toHaveBeenCalledWith('/');
     });
 
-    it('does not call acceptInvite without signing in first', async () => {
+    it('does not call acceptInvite without signing in first', () => {
       render(<EmailSignInPage />);
 
       // Simply rendering the page with invite param should not call acceptInvite
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mockAcceptInvite).not.toHaveBeenCalled();
+    });
+
+    it('shows Firebase credential error even when invite token is present', async () => {
+      const user = userEvent.setup();
+      const firebaseError = new Error('Firebase: Error (auth/invalid-credential).');
+      (firebaseError as { code?: string }).code = 'auth/invalid-credential';
+      mockSignInWithEmailAndPassword.mockRejectedValue(firebaseError);
+
+      render(<EmailSignInPage />);
+
+      await user.type(screen.getByLabelText(/email address/i), 'test@example.com');
+      await user.type(screen.getByLabelText(/^password$/i), 'wrongpassword');
+      await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/invalid email or password/i)).toBeInTheDocument();
+      });
       expect(mockAcceptInvite).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/app/(public)/auth/signin/email/page.tsx
+++ b/frontend/src/app/(public)/auth/signin/email/page.tsx
@@ -147,6 +147,7 @@ function EmailSignInContent() {
         } else {
           setSubmitError('Sign in failed. Please try again.');
         }
+      } finally {
         setIsLoading(false);
       }
     },


### PR DESCRIPTION
## Summary
- Add optional `?invite=<token>` query param to `/auth/signin/email`
- After successful Firebase sign-in, if invite param is present, calls `acceptInvite(token)` and redirects based on role
- Suppresses the default `isAuthenticated` auto-redirect when invite param is present

## Changes
- `page.tsx`: Added `useSearchParams` to read invite token, `handleAcceptInvite` callback with error handling, `redirectBasedOnRole` helper, and conditional invite flow in `handleSubmit`
- `page.test.tsx`: 9 new tests covering invite success (3 role variants), error handling (expired, consumed, unknown), auto-redirect suppression, no spurious API calls, and Firebase credential errors with invite token

## Test plan
- [x] All 2227 frontend tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors)
- [ ] Manual: send invitation, sign in at `/auth/signin/email?invite=<id>` → user created, redirected by role

Beads: PLAT-dnv7

Generated with Claude Code