### PR TITLE
fix: resolve race condition in email sign-in invite flow

### DIFF
--- a/frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx
+++ b/frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx
@@ -18,7 +18,6 @@ jest.mock('next/navigation', () => ({
   useSearchParams: jest.fn(() => new URLSearchParams()),
 }));
 
-// Mock AuthContext — refreshUser is NOT needed (no test mode branch)
 jest.mock('@/contexts/AuthContext', () => ({
   useAuth: jest.fn(),
 }));
@@ -47,14 +46,17 @@ const mockAcceptInvite = acceptInvite as jest.Mock;
 
 describe('EmailSignInPage', () => {
   const mockPush = jest.fn();
+  const mockRefreshUser = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRefreshUser.mockResolvedValue(undefined);
     (useRouter as jest.Mock).mockReturnValue({
       push: mockPush,
     });
     (useAuth as jest.Mock).mockReturnValue({
       isAuthenticated: false,
+      refreshUser: mockRefreshUser,
     });
   });
 
@@ -92,6 +94,7 @@ describe('EmailSignInPage', () => {
     it('redirects to home when already authenticated', async () => {
       (useAuth as jest.Mock).mockReturnValue({
         isAuthenticated: true,
+        refreshUser: mockRefreshUser,
       });
 
       render(<EmailSignInPage />);
@@ -135,7 +138,7 @@ describe('EmailSignInPage', () => {
       await user.click(screen.getByRole('button', { name: /sign in/i }));
 
       // Simulate AuthContext updating isAuthenticated
-      (useAuth as jest.Mock).mockReturnValue({ isAuthenticated: true });
+      (useAuth as jest.Mock).mockReturnValue({ isAuthenticated: true, refreshUser: mockRefreshUser });
       rerender(<EmailSignInPage />);
 
       await waitFor(() => {
@@ -397,11 +400,34 @@ describe('EmailSignInPage', () => {
       expect(mockPush).not.toHaveBeenCalled();
     });
 
+    it('calls refreshUser after accepting invite to sync AuthContext before redirect', async () => {
+      const user = userEvent.setup();
+      mockSignInWithEmailAndPassword.mockResolvedValue({
+        user: { uid: 'test-uid', email: 'test@example.com' },
+      });
+      mockAcceptInvite.mockResolvedValue({ role: 'instructor' });
+
+      render(<EmailSignInPage />);
+
+      await user.type(screen.getByLabelText(/email address/i), 'test@example.com');
+      await user.type(screen.getByLabelText(/^password$/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+      await waitFor(() => {
+        expect(mockRefreshUser).toHaveBeenCalled();
+      });
+      // refreshUser must be called before the redirect
+      const refreshOrder = mockRefreshUser.mock.invocationCallOrder[0];
+      const pushOrder = mockPush.mock.invocationCallOrder[0];
+      expect(refreshOrder).toBeLessThan(pushOrder);
+    });
+
     it('does NOT redirect to / when isAuthenticated becomes true (suppresses auto-redirect)', () => {
       // When invite param is present, the isAuthenticated redirect should be suppressed
       // so that acceptInvite can run and redirect based on role instead.
       (useAuth as jest.Mock).mockReturnValue({
         isAuthenticated: true,
+        refreshUser: mockRefreshUser,
       });
 
       render(<EmailSignInPage />);

--- a/frontend/src/app/(public)/auth/signin/email/page.tsx
+++ b/frontend/src/app/(public)/auth/signin/email/page.tsx
@@ -47,7 +47,7 @@ function EmailSignInContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const inviteToken = searchParams.get('invite');
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, refreshUser } = useAuth();
 
   // Redirect when authenticated (AuthContext picks up Firebase user).
   // Suppressed when invite param is present — acceptInvite handles the redirect instead.
@@ -76,6 +76,11 @@ function EmailSignInContent() {
     async (token: string) => {
       try {
         const data = await acceptInvite(token);
+        // Update AuthContext with the new user before redirecting.
+        // Without this, onAuthStateChanged races with acceptInvite and
+        // sets user to null (bootstrap 403), so the app layout bounces
+        // us back to sign-in.
+        await refreshUser();
         redirectBasedOnRole(data.role);
       } catch (error) {
         if (error instanceof ApiError) {
@@ -93,7 +98,7 @@ function EmailSignInContent() {
         setIsLoading(false);
       }
     },
-    [redirectBasedOnRole]
+    [redirectBasedOnRole, refreshUser]
   );
 
   const validate = useCallback((): boolean => {


### PR DESCRIPTION
## Summary
- Fix silent failure when accepting email invites — user was stuck on sign-in page with no error
- `onAuthStateChanged` races with `handleAcceptInvite` after Firebase sign-in, causing AuthContext to set `user=null` (bootstrap 403) before the invite redirect completes
- Call `refreshUser()` after `acceptInvite` succeeds to sync AuthContext before redirecting

## Changes
- `frontend/src/app/(public)/auth/signin/email/page.tsx`: add `refreshUser()` call after successful invite acceptance
- `frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx`: add test verifying `refreshUser` is called before redirect, update mocks

## Test plan
- [x] All 25 email sign-in tests pass (including new race condition test)

Beads: PLAT-vtw3

Generated with Claude Code