### PR TITLE
fix: resolve intermittent E2E auth hydration failures in CI

### DIFF
--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -5,6 +5,10 @@ import { TEST_USER_KEY } from '../../src/lib/auth-provider';
  * Sign in by directly setting localStorage — bypasses the sign-in UI entirely.
  * Sets testAuthUser in localStorage so TestAuthProvider hydrates on navigation to /.
  * The backend validates the token format test:<externalId>:<email>.
+ *
+ * Waits for auth hydration to complete — the landing page at "/" redirects
+ * authenticated users to their role-appropriate dashboard (/instructor, /system, etc.).
+ * This ensures the caller doesn't proceed until the user is fully authenticated.
  */
 export async function signInAs(
   page: Page,
@@ -16,8 +20,13 @@ export async function signInAs(
     localStorage.setItem(key, JSON.stringify({ externalId, email }));
   }, { key: TEST_USER_KEY, externalId, email });
   await page.goto('/');  // reload so TestAuthProvider picks up the token
-  // Wait for redirect away from any signin page (auth hydration complete)
-  await page.waitForURL(/^(?!.*\/auth\/signin).*$/);
+  // Wait for auth hydration to complete — the landing page redirects
+  // authenticated users away from "/" to their role-appropriate dashboard.
+  // Timeout allows for API retry logic (~7s) on transient network failures.
+  await page.waitForURL((url) => {
+    const path = new URL(url).pathname;
+    return path !== '/' && !path.startsWith('/auth/');
+  }, { timeout: 15_000 });
 }
 
 export async function loginAsInstructor(page: Page, email?: string): Promise<void> {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -49,7 +49,13 @@ function TestAuthProvider({ children }: AuthProviderProps) {
           setUser(profile);
         } catch (error) {
           console.error('[Auth] Error hydrating user:', error);
-          clearTestUser();
+          // Only clear the test token on definitive auth failures (401/403/404).
+          // Transient network errors (TypeError: Failed to fetch) should NOT
+          // destroy the token — the next page navigation will retry hydration.
+          const status = (error as { status?: number }).status;
+          if (status === 401 || status === 403 || status === 404) {
+            clearTestUser();
+          }
         }
       }
       setIsLoading(false);

--- a/frontend/src/contexts/__tests__/TestAuthProvider.test.tsx
+++ b/frontend/src/contexts/__tests__/TestAuthProvider.test.tsx
@@ -186,6 +186,51 @@ describe('TestAuthProvider', () => {
     expect(typeof result.current.isAuthenticated).toBe('boolean');
   });
 
+  it('does NOT clear test token on transient network errors during hydration', async () => {
+    mockGetTestToken.mockReturnValue('some-token');
+    // Simulate a network error (TypeError: Failed to fetch) — no status property
+    mockGetCurrentUser.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const { AuthProvider, useAuth } = require('../AuthContext');
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Token should NOT be cleared — allows retry on next navigation
+    expect(mockClearTestUser).not.toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('clears test token on auth errors (401/403/404) during hydration', async () => {
+    mockGetTestToken.mockReturnValue('some-token');
+    // Simulate a 403 auth error with a status property
+    const authError = Object.assign(new Error('Forbidden'), { status: 403 });
+    mockGetCurrentUser.mockRejectedValue(authError);
+
+    const { AuthProvider, useAuth } = require('../AuthContext');
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Token SHOULD be cleared for definitive auth failures
+    expect(mockClearTestUser).toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
   it('does not expose signIn method — sign-in is handled by SignInButtons component', async () => {
     const { AuthProvider, useAuth } = require('../AuthContext');
 


### PR DESCRIPTION
## Summary

- **signInAs()** now waits for the auth-driven redirect (`/` → `/system`, `/instructor`, etc.) instead of returning immediately, ensuring auth hydration completed before tests proceed
- **TestAuthProvider** only clears the test token on definitive auth failures (401/403/404), not transient network errors (`TypeError: Failed to fetch`), allowing retry on next page navigation
- Added unit tests verifying both behaviors (network errors preserve token, auth errors clear it)

## Root cause

E2E tests failed intermittently in CI with `[Auth] Error hydrating user: TypeError: Failed to fetch`. The Next.js standalone proxy intermittently failed to forward requests to the Go API (requests never reached the backend). Two bugs made this fatal:

1. `signInAs()` returned before auth hydration started — the `waitForURL` regex matched `/` immediately
2. `clearTestUser()` permanently destroyed the localStorage token on any error, preventing recovery

## Test plan

- [x] All 7 E2E tests pass locally (verified 2x)
- [x] All 2231 unit tests pass (2 new tests added)
- [x] Lint and typecheck clean
- [ ] CI E2E tests pass (the real proof — this was only reproducible in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)