### PR TITLE
chore: rename Coding Tool branding to Eval

### DIFF
--- a/frontend/src/app/(public)/auth/signin/page.tsx
+++ b/frontend/src/app/(public)/auth/signin/page.tsx
@@ -67,7 +67,7 @@ function SignInPageContent() {
             </div>
           </div>
           <h2 className="text-center text-3xl font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
-            Coding Tool
+            Eval
           </h2>
           <p className="mt-3 text-center text-sm text-gray-600">
             Sign in to your account

--- a/frontend/src/components/layout/GlobalHeader.tsx
+++ b/frontend/src/components/layout/GlobalHeader.tsx
@@ -36,9 +36,9 @@ export function GlobalHeader({ onMobileMenuToggle, showMobileMenu = false }: Glo
         )}
         <div className="flex items-center gap-2">
           <div className="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center">
-            <span className="text-white font-bold text-sm">CT</span>
+            <span className="text-white font-bold text-sm">E</span>
           </div>
-          <span className="font-semibold text-gray-900 hidden sm:inline">Coding Tool</span>
+          <span className="font-semibold text-gray-900 hidden sm:inline">Eval</span>
         </div>
       </div>
 

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -166,9 +166,9 @@ export function MobileNav({ isOpen, onClose }: MobileNavProps) {
         <div className="h-14 flex items-center justify-between px-4 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <div className="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center">
-              <span className="text-white font-bold text-sm">CT</span>
+              <span className="text-white font-bold text-sm">E</span>
             </div>
-            <span className="font-semibold text-gray-900">Coding Tool</span>
+            <span className="font-semibold text-gray-900">Eval</span>
           </div>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- Rename "Coding Tool" → "Eval" in header, mobile nav, and sign-in page
- Update logo monogram from "CT" → "E"

## Changes
- `GlobalHeader.tsx` — brand name and logo text
- `MobileNav.tsx` — brand name and logo text
- `signin/page.tsx` — heading text

## Test plan
- [ ] Verify header shows "Eval" with "E" logo on desktop
- [ ] Verify mobile nav shows "Eval" with "E" logo
- [ ] Verify sign-in page heading shows "Eval"

Beads: PLAT-8fiq

Generated with Claude Code