### PR TITLE
fix: refine coordinator skill prompts and quality gate delegation

### DIFF
--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -103,28 +103,16 @@ Commit test files when done. Do not modify beads issues.
 
 **On SUCCESS:** Proceed to step c — spec tests are committed and failing.
 
-**On FAILURE:** If task description is too vague, clarify and re-spawn. If the task genuinely doesn't need behavioral tests (e.g., pure config changes), skip to step c and the implementer will write all tests in standalone mode.
+**On FAILURE:** Proceed to step c anyway — the implementer owns full testing responsibility regardless.
 
 #### c. Spawn Implementer
 
 Use the Task tool with `subagent_type: "general-purpose"` and `model: "sonnet"`:
 
-**With spec tests (normal flow):**
 ```
 SKILL: .claude/skills/implementer/SKILL.md
 WORKTREE: ../<project>-<work-name>
 TASK: bd show <task-id> --json
-SPEC TESTS: Yes — read the test files from the test specifier summary.
-Do not modify spec test files — flag issues in your summary. Do not modify beads issues.
-Commit and push when done.
-```
-
-**Without spec tests (fallback):**
-```
-SKILL: .claude/skills/implementer/SKILL.md
-WORKTREE: ../<project>-<work-name>
-TASK: bd show <task-id> --json
-SPEC TESTS: No — use standalone mode.
 Do not modify beads issues. Commit and push when done.
 ```
 
@@ -136,11 +124,7 @@ The implementer's final output is a structured summary (Phase 5). Only read that
 ```bash
 bd close <task-id> --reason "Implemented" --json
 ```
-Check the "Concerns" section — file follow-up issues if needed.
-
-Check the "Spec test issues" section. If the implementer flagged problems with spec tests:
-- **Trivial** (wrong assertion value, typo in test name): fix directly, commit
-- **Non-trivial** (spec test encodes wrong behavior): re-spawn test specifier with clarification, then re-spawn implementer
+Check "Concerns" and "Spec test issues" sections — file follow-up issues if needed.
 
 **On FAILURE:**
 - If recoverable: fix directly or spawn new subagent with clarification

--- a/.claude/skills/implementer/SKILL.md
+++ b/.claude/skills/implementer/SKILL.md
@@ -18,25 +18,17 @@ This skill covers development only — no issue tracking, no commits, no pushes.
 - **Every production code change requires tests.** No exceptions for migrations, refactors, copy-paste, or "just wiring things up." If you wrote or modified production code, you must write tests for it. Never defer tests to a follow-up issue.
 - **Delegate quality gates to test-runner sub-agents.** Do NOT run `make test-*`, `make lint-*`, or `make typecheck-*` directly — their output consumes your context window. Use the Task tool to spawn a test-runner (see Phase 3). Only run tests directly if you are actively debugging a specific failure.
 
-## Phase 1: Understand the Spec
+## Spec Tests
 
-How you approach this phase depends on whether spec tests were provided by a test specifier.
+A test specifier may have run before you and committed **behavioral tests** — tests that encode the planner's intent as executable assertions. These are a head start, not a complete specification. You still own full testing responsibility.
 
-### With Spec Tests (test specifier ran before you)
+If spec tests exist in the worktree:
+- Read them first to understand expected behavior and implementation hints
+- Do NOT modify them — if one appears wrong, flag it in Phase 5 under "Spec test issues"
+- They must pass along with all other tests in Phase 3
+- They do NOT reduce your obligation to write thorough tests in Phase 1
 
-The test specifier has already written **behavioral tests** — tests that define the contract for what the system should do. These tests are already committed and failing.
-
-1. Read the spec test files to understand the expected behavior
-2. Read any implementation hints at the top of test files
-3. Read the relevant production code to understand the starting point
-
-**Constraint: Do NOT modify the spec tests.** They are the contract. If you believe a spec test is wrong (testing impossible behavior, incorrect assertions, broken test setup), flag it in your Phase 5 summary under "Spec test issues" rather than changing it. The coordinator will handle it.
-
-You MAY add your own unit tests during Phase 2 for implementation decisions (internal helpers, complex logic branches, etc.). These complement the spec tests — they don't replace them.
-
-**Gate:** You understand what the spec tests expect and have a mental model for how to make them pass.
-
-### Without Spec Tests (standalone mode)
+## Phase 1: Write Failing Tests
 
 Write tests for the behavior you are about to change or add. Do this **before** touching any production code.
 
@@ -45,6 +37,7 @@ Write tests for the behavior you are about to change or add. Do this **before** 
 - "It's just wiring up an API client" — API client calls, error handling, and auth headers need tests
 - "The old code didn't have tests" — that's a reason to add them, not skip them
 - "I'll add tests later" — no, tests ship with the code, always
+- "The spec tests already cover it" — spec tests encode intent, not complete coverage. Write your own tests for the behavior you're implementing.
 
 1. Read the relevant production code to understand current behavior
 2. Write new test cases that describe the desired behavior after your change
@@ -55,14 +48,6 @@ Write tests for the behavior you are about to change or add. Do this **before** 
 ## Phase 2: Implement
 
 Make the production code changes. Keep changes minimal and focused on the task.
-
-Add **unit tests** as you go for implementation decisions the spec tests don't cover:
-- Internal helper functions you create
-- Complex logic branches within a function
-- Table-driven tests for parsers or validators with many cases
-- Retry/fallback mechanisms you choose to add
-
-These unit tests test your implementation's internal structure. The spec tests test the external behavior. Both are valuable; they serve different purposes.
 
 ## Phase 3: Verify
 
@@ -81,16 +66,16 @@ For frontend changes: make test-frontend, make lint-frontend, make typecheck-fro
 For store changes, also: make test-integration-store
 ```
 
-**Gate:** Sub-agent reports PASS. If FAIL, read the error summary, fix the issue, and re-delegate. Only run quality gates directly in your own context if you need to debug a failure interactively.
+**Gate:** Sub-agent reports PASS (including any spec tests). If FAIL, read the error summary, fix the issue, and re-delegate. Only run quality gates directly in your own context if you need to debug a failure interactively.
 
 ## Phase 4: Test Coverage Audit
 
-Evaluate whether tests (spec tests + your unit tests) actually cover the changes you made. Do NOT re-read files you already have in context from writing them.
+Evaluate whether your tests actually cover the changes you made. Do NOT re-read files you already have in context from writing them.
 
 1. List changed files: `git diff --name-only`
 2. For each changed production file, evaluate from what you already know:
    - What behavior changed? (new feature, bug fix, removed feature, refactored logic)
-   - Do tests cover: happy path, error paths, edge cases, regressions?
+   - Do your tests cover: happy path, error paths, edge cases, regressions?
    - Are integration tests needed? (persistence, API routes, auth, cross-layer data flow)
 3. If gaps exist: write the missing tests, then re-run quality gates via test-runner sub-agent (same as Phase 3).
 


### PR DESCRIPTION
## Summary
- Trims verbose coordinator subagent prompts to just task-specific parameters (skills define behavior)
- Removes ambiguous "Spec → Implement → Handle" shorthand
- Explicitly delegates pre-PR quality gates to test-runner sub-agent

Follow-up to #102. These changes were made after that PR was merged.

Generated with Claude Code