### PR TITLE
fix: include execution_settings in student_code_updated realtime event

### DIFF
--- a/frontend/src/hooks/__tests__/useRealtimeSession.test.ts
+++ b/frontend/src/hooks/__tests__/useRealtimeSession.test.ts
@@ -596,6 +596,79 @@ describe('useRealtimeSession', () => {
       expect(result.current.students[0].code).toBe('print("updated")');
     });
 
+    it('should store execution_settings from student_code_updated event on the student', async () => {
+      const { result } = renderHook(() =>
+        useRealtimeSession({
+          session_id: 'session-1',
+          user_id: 'user-1',
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Add a student first
+      act(() => {
+        simulatePublication('student_joined', {
+          user_id: 'student-1',
+          display_name: 'Alice',
+        });
+      });
+
+      expect(result.current.students[0].execution_settings).toBeUndefined();
+
+      const execSettings = { stdin: 'hello inputs', random_seed: 42 };
+      act(() => {
+        simulatePublication('student_code_updated', {
+          user_id: 'student-1',
+          code: 'print("hello")',
+          execution_settings: execSettings,
+        });
+      });
+
+      expect(result.current.students[0].code).toBe('print("hello")');
+      expect(result.current.students[0].execution_settings).toEqual(execSettings);
+    });
+
+    it('should store execution_settings from student_code_updated in pending updates (out-of-order)', async () => {
+      const { result } = renderHook(() =>
+        useRealtimeSession({
+          session_id: 'session-1',
+          user_id: 'user-1',
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      const execSettings = { stdin: 'pending inputs' };
+
+      // Code update (with execution_settings) arrives before student join
+      act(() => {
+        simulatePublication('student_code_updated', {
+          user_id: 'student-1',
+          code: 'print("early")',
+          execution_settings: execSettings,
+        });
+      });
+
+      expect(result.current.students).toHaveLength(0);
+
+      // Student join arrives after — should apply pending update including execution_settings
+      act(() => {
+        simulatePublication('student_joined', {
+          user_id: 'student-1',
+          display_name: 'Alice',
+        });
+      });
+
+      expect(result.current.students).toHaveLength(1);
+      expect(result.current.students[0].code).toBe('print("early")');
+      expect(result.current.students[0].execution_settings).toEqual(execSettings);
+    });
+
     it('should handle out-of-order events (code update before student join)', async () => {
       const { result } = renderHook(() =>
         useRealtimeSession({

--- a/frontend/src/hooks/useRealtimeSession.ts
+++ b/frontend/src/hooks/useRealtimeSession.ts
@@ -259,9 +259,10 @@ export function useRealtimeSession({
 
         case 'student_code_updated': {
           if (payload) {
-            // Backend sends StudentCodeUpdatedData{user_id, code}
+            // Backend sends StudentCodeUpdatedData{user_id, code, execution_settings}
             const studentId = payload.user_id;
             const code = payload.code;
+            const executionSettings = payload.execution_settings;
             setStudents(prev => {
               const updated = new Map(prev);
               const student = updated.get(studentId);
@@ -269,11 +270,13 @@ export function useRealtimeSession({
                 updated.set(studentId, {
                   ...student,
                   code: code || '',
+                  ...(executionSettings !== undefined && { execution_settings: executionSettings }),
                   last_update: new Date(),
                 });
               } else {
                 pendingCodeUpdatesRef.current.set(studentId, {
                   code: code || '',
+                  ...(executionSettings !== undefined && { execution_settings: executionSettings }),
                 });
               }
               return updated;

--- a/go-backend/internal/handler/session_students.go
+++ b/go-backend/internal/handler/session_students.go
@@ -170,7 +170,7 @@ func (h *SessionStudentHandler) UpdateCode(w http.ResponseWriter, r *http.Reques
 		h.revBuffer.Record(r.Context(), nsID, *sessionStudent.StudentWorkID, &sessionID, authUser.ID, req.Code)
 	}
 
-	_ = h.publisher.CodeUpdated(r.Context(), sessionID.String(), authUser.ID.String(), req.Code)
+	_ = h.publisher.CodeUpdated(r.Context(), sessionID.String(), authUser.ID.String(), req.Code, req.ExecutionSettings)
 
 	// Build response using student_work data
 	sessionStudent.Code = studentWork.Code

--- a/go-backend/internal/handler/session_students_test.go
+++ b/go-backend/internal/handler/session_students_test.go
@@ -1062,6 +1062,71 @@ func TestUpdateCode_PublishesCodeUpdated(t *testing.T) {
 	}
 }
 
+// TestUpdateCode_PublishesExecutionSettings verifies that execution_settings from
+// the request body are forwarded to the CodeUpdated publisher call.
+func TestUpdateCode_PublishesExecutionSettings(t *testing.T) {
+	ss := testSessionStudent()
+	studentWorkID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	ss.StudentWorkID = &studentWorkID
+	ss.Code = "x = 1"
+	userID := ss.UserID
+	execSettings := json.RawMessage(`{"stdin":"hello inputs"}`)
+
+	studentRepo := &mockSessionStudentRepo{
+		getSessionStudentFn: func(_ context.Context, _, _ uuid.UUID) (*store.SessionStudent, error) {
+			return ss, nil
+		},
+	}
+
+	workRepo := &mockStudentWorkRepo{
+		updateStudentWorkFn: func(_ context.Context, _ uuid.UUID, params store.UpdateStudentWorkParams) (*store.StudentWork, error) {
+			return &store.StudentWork{
+				ID:                studentWorkID,
+				Code:              *params.Code,
+				ExecutionSettings: params.ExecutionSettings,
+			}, nil
+		},
+	}
+
+	pub := newMockPublisher()
+	h := NewSessionStudentHandler(pub)
+
+	body := []byte(`{"code":"x = 1","execution_settings":{"stdin":"hello inputs"}}`)
+	req := httptest.NewRequest(http.MethodPut, "/sessions/"+ss.SessionID.String()+"/code", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := withChiParam(req.Context(), "id", ss.SessionID.String())
+	ctx = auth.WithUser(ctx, &auth.User{ID: userID, NamespaceID: "test-ns", Role: auth.RoleStudent})
+	ctx = store.WithRepos(ctx, studReposWithAllMocks(studentRepo, nil, workRepo))
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.UpdateCode(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	pub.waitForCalls(t, 1)
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.codeUpdatedCalls) != 1 {
+		t.Fatalf("expected 1 CodeUpdated call, got %d", len(pub.codeUpdatedCalls))
+	}
+	call := pub.codeUpdatedCalls[0]
+	if call.executionSettings == nil {
+		t.Fatal("expected execution_settings to be forwarded to publisher, got nil")
+	}
+	var gotMap, wantMap map[string]any
+	if err := json.Unmarshal(call.executionSettings, &gotMap); err != nil {
+		t.Fatalf("unmarshal got: %v", err)
+	}
+	if err := json.Unmarshal(execSettings, &wantMap); err != nil {
+		t.Fatalf("unmarshal want: %v", err)
+	}
+	if gotMap["stdin"] != wantMap["stdin"] {
+		t.Errorf("execution_settings.stdin: got %v, want %v", gotMap["stdin"], wantMap["stdin"])
+	}
+}
+
 func TestUpdateCode_SucceedsWhenPublisherFails(t *testing.T) {
 	ss := testSessionStudent()
 	studentWorkID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")

--- a/go-backend/internal/handler/testutil_test.go
+++ b/go-backend/internal/handler/testutil_test.go
@@ -114,6 +114,7 @@ type studentJoinedCall struct {
 }
 type codeUpdatedCall struct {
 	sessionID, userID, code string
+	executionSettings       json.RawMessage
 }
 type sessionEndedCall struct {
 	sessionID, reason string
@@ -156,9 +157,9 @@ func (m *mockSessionPublisher) StudentJoined(_ context.Context, sessionID, userI
 	m.done <- struct{}{}
 	return m.err
 }
-func (m *mockSessionPublisher) CodeUpdated(_ context.Context, sessionID, userID, code string) error {
+func (m *mockSessionPublisher) CodeUpdated(_ context.Context, sessionID, userID, code string, executionSettings json.RawMessage) error {
 	m.mu.Lock()
-	m.codeUpdatedCalls = append(m.codeUpdatedCalls, codeUpdatedCall{sessionID, userID, code})
+	m.codeUpdatedCalls = append(m.codeUpdatedCalls, codeUpdatedCall{sessionID, userID, code, executionSettings})
 	m.mu.Unlock()
 	m.done <- struct{}{}
 	return m.err

--- a/go-backend/internal/realtime/async_publisher.go
+++ b/go-backend/internal/realtime/async_publisher.go
@@ -47,9 +47,9 @@ func (a *AsyncSessionPublisher) StudentJoined(ctx context.Context, sessionID, us
 	return nil
 }
 
-func (a *AsyncSessionPublisher) CodeUpdated(ctx context.Context, sessionID, userID, code string) error {
+func (a *AsyncSessionPublisher) CodeUpdated(ctx context.Context, sessionID, userID, code string, executionSettings json.RawMessage) error {
 	a.runAsync(ctx, "CodeUpdated", func(ctx context.Context) error {
-		return a.inner.CodeUpdated(ctx, sessionID, userID, code)
+		return a.inner.CodeUpdated(ctx, sessionID, userID, code, executionSettings)
 	})
 	return nil
 }

--- a/go-backend/internal/realtime/async_publisher_test.go
+++ b/go-backend/internal/realtime/async_publisher_test.go
@@ -49,7 +49,7 @@ func (r *recordingPublisher) waitForCalls(t *testing.T, n int) {
 func (r *recordingPublisher) StudentJoined(_ context.Context, _, _, _ string) error {
 	return r.record("StudentJoined")
 }
-func (r *recordingPublisher) CodeUpdated(_ context.Context, _, _, _ string) error {
+func (r *recordingPublisher) CodeUpdated(_ context.Context, _, _, _ string, _ json.RawMessage) error {
 	return r.record("CodeUpdated")
 }
 func (r *recordingPublisher) SessionEnded(_ context.Context, _, _ string) error {
@@ -89,7 +89,7 @@ func TestAsyncSessionPublisher_CodeUpdated(t *testing.T) {
 	rec := newRecordingPublisher()
 	ap := NewAsyncSessionPublisher(rec, discardLogger())
 
-	err := ap.CodeUpdated(context.Background(), "sess-1", "user-1", "code")
+	err := ap.CodeUpdated(context.Background(), "sess-1", "user-1", "code", nil)
 	if err != nil {
 		t.Fatalf("expected nil error from async call, got %v", err)
 	}
@@ -178,7 +178,7 @@ func TestAsyncSessionPublisher_MultipleCalls(t *testing.T) {
 	ap := NewAsyncSessionPublisher(rec, discardLogger())
 
 	_ = ap.StudentJoined(context.Background(), "s1", "u1", "Alice")
-	_ = ap.CodeUpdated(context.Background(), "s1", "u1", "code")
+	_ = ap.CodeUpdated(context.Background(), "s1", "u1", "code", nil)
 	_ = ap.SessionEnded(context.Background(), "s1", "done")
 
 	rec.waitForCalls(t, 3)

--- a/go-backend/internal/realtime/events.go
+++ b/go-backend/internal/realtime/events.go
@@ -32,8 +32,9 @@ type StudentJoinedData struct {
 
 // StudentCodeUpdatedData is the payload for EventStudentCodeUpdated.
 type StudentCodeUpdatedData struct {
-	UserID string `json:"user_id"`
-	Code   string `json:"code"`
+	UserID            string          `json:"user_id"`
+	Code              string          `json:"code"`
+	ExecutionSettings json.RawMessage `json:"execution_settings,omitempty"`
 }
 
 // SessionEndedData is the payload for EventSessionEnded.

--- a/go-backend/internal/realtime/noop.go
+++ b/go-backend/internal/realtime/noop.go
@@ -13,7 +13,9 @@ var _ SessionPublisher = NoOpSessionPublisher{}
 type NoOpSessionPublisher struct{}
 
 func (NoOpSessionPublisher) StudentJoined(_ context.Context, _, _, _ string) error    { return nil }
-func (NoOpSessionPublisher) CodeUpdated(_ context.Context, _, _, _ string) error      { return nil }
+func (NoOpSessionPublisher) CodeUpdated(_ context.Context, _, _, _ string, _ json.RawMessage) error {
+	return nil
+}
 func (NoOpSessionPublisher) SessionEnded(_ context.Context, _, _ string) error        { return nil }
 func (NoOpSessionPublisher) SessionReplaced(_ context.Context, _, _ string) error     { return nil }
 func (NoOpSessionPublisher) FeaturedStudentChanged(_ context.Context, _, _, _ string, _ json.RawMessage) error {

--- a/go-backend/internal/realtime/session_publisher.go
+++ b/go-backend/internal/realtime/session_publisher.go
@@ -10,7 +10,7 @@ import (
 // SessionPublisher provides typed methods for publishing session events.
 type SessionPublisher interface {
 	StudentJoined(ctx context.Context, sessionID, userID, displayName string) error
-	CodeUpdated(ctx context.Context, sessionID, userID, code string) error
+	CodeUpdated(ctx context.Context, sessionID, userID, code string, executionSettings json.RawMessage) error
 	SessionEnded(ctx context.Context, sessionID, reason string) error
 	SessionReplaced(ctx context.Context, oldSessionID, newSessionID string) error
 	FeaturedStudentChanged(ctx context.Context, sessionID, userID, code string, executionSettings json.RawMessage) error
@@ -50,10 +50,11 @@ func (s *sessionPublisher) StudentJoined(ctx context.Context, sessionID, userID,
 	})
 }
 
-func (s *sessionPublisher) CodeUpdated(ctx context.Context, sessionID, userID, code string) error {
+func (s *sessionPublisher) CodeUpdated(ctx context.Context, sessionID, userID, code string, executionSettings json.RawMessage) error {
 	return s.publish(ctx, sessionID, EventStudentCodeUpdated, StudentCodeUpdatedData{
-		UserID: userID,
-		Code:   code,
+		UserID:            userID,
+		Code:              code,
+		ExecutionSettings: executionSettings,
 	})
 }
 

--- a/go-backend/internal/realtime/session_publisher_test.go
+++ b/go-backend/internal/realtime/session_publisher_test.go
@@ -62,7 +62,8 @@ func TestStudentJoined(t *testing.T) {
 
 func TestCodeUpdated(t *testing.T) {
 	mock, sp := newTestPublisher()
-	err := sp.CodeUpdated(context.Background(), "sess-2", "user-2", "fmt.Println()")
+	execSettings := json.RawMessage(`{"stdin":"world"}`)
+	err := sp.CodeUpdated(context.Background(), "sess-2", "user-2", "fmt.Println()", execSettings)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -76,6 +77,22 @@ func TestCodeUpdated(t *testing.T) {
 	data := event.Data.(StudentCodeUpdatedData)
 	if data.UserID != "user-2" || data.Code != "fmt.Println()" {
 		t.Errorf("payload = %+v", data)
+	}
+	if string(data.ExecutionSettings) != `{"stdin":"world"}` {
+		t.Errorf("execution_settings = %q, want %q", string(data.ExecutionSettings), `{"stdin":"world"}`)
+	}
+}
+
+func TestCodeUpdated_NilExecutionSettings(t *testing.T) {
+	mock, sp := newTestPublisher()
+	err := sp.CodeUpdated(context.Background(), "sess-2", "user-2", "fmt.Println()", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	event := mock.data.(Event)
+	data := event.Data.(StudentCodeUpdatedData)
+	if data.ExecutionSettings != nil {
+		t.Errorf("expected nil execution_settings, got %q", string(data.ExecutionSettings))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Featured students' code inputs (stdin) were not populated on the public view because the `student_code_updated` realtime event only published `code`, not `execution_settings`
- Added `execution_settings` to the `StudentCodeUpdatedData` event payload and propagated it through the publisher chain
- Updated the frontend `student_code_updated` handler to store received `execution_settings` on the student

## Changes
- `go-backend/internal/realtime/events.go` — added `ExecutionSettings json.RawMessage` to `StudentCodeUpdatedData`
- `go-backend/internal/realtime/session_publisher.go` — updated `SessionPublisher` interface and implementation
- `go-backend/internal/realtime/noop.go`, `async_publisher.go` — updated alternate implementations
- `go-backend/internal/handler/session_students.go` — pass `req.ExecutionSettings` to `CodeUpdated`
- `frontend/src/hooks/useRealtimeSession.ts` — store `execution_settings` from event on student

## Test plan
- [x] Go unit tests pass (publisher, handler)
- [x] Frontend unit tests pass (in-order and out-of-order event paths)
- [x] All linters pass
- [x] TypeScript typecheck passes

Beads: PLAT-7cfm

Generated with Claude Code