### PR TITLE
fix: replace deprecated gemini-2.0-flash with gemini-2.5-flash

### DIFF
--- a/frontend/src/app/(app)/instructor/components/SessionStudentPane.tsx
+++ b/frontend/src/app/(app)/instructor/components/SessionStudentPane.tsx
@@ -16,7 +16,7 @@ import { Problem, ExecutionSettings } from '@/types/problem';
 import useAnalysisGroups from '../hooks/useAnalysisGroups';
 import { Student, RealtimeStudent, ExecutionResult } from '../types';
 
-const DEFAULT_MODEL = 'gemini-2.0-flash';
+const DEFAULT_MODEL = 'gemini-2.5-flash';
 
 // DEFAULT_PROMPT must match the backend's DefaultCustomDirections in go-backend/internal/ai/prompt.go.
 // When the instructor clicks Analyze without editing, this is exactly what the backend uses.
@@ -235,7 +235,6 @@ export function SessionStudentPane({
                   onChange={e => setSelectedModel(e.target.value)}
                   className="w-full text-sm border border-gray-300 rounded px-2 py-1"
                 >
-                  <option value="gemini-2.0-flash">Gemini 2.0 Flash</option>
                   <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
                 </select>
               </div>

--- a/frontend/src/app/(app)/instructor/components/__tests__/SessionStudentPane.test.tsx
+++ b/frontend/src/app/(app)/instructor/components/__tests__/SessionStudentPane.test.tsx
@@ -300,16 +300,16 @@ describe('SessionStudentPane', () => {
         fireEvent.click(screen.getByTestId('analysis-options-toggle'));
       });
 
-      it('shows a model dropdown with Gemini 2.0 Flash and Gemini 2.5 Flash options', () => {
+      it('shows a model dropdown with only Gemini 2.5 Flash option (2.0 removed)', () => {
         const select = screen.getByTestId('model-select');
         expect(select).toBeInTheDocument();
-        expect(screen.getByRole('option', { name: /gemini 2\.0 flash/i })).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: /gemini 2\.0 flash/i })).not.toBeInTheDocument();
         expect(screen.getByRole('option', { name: /gemini 2\.5 flash/i })).toBeInTheDocument();
       });
 
-      it('defaults model dropdown to Gemini 2.0 Flash', () => {
+      it('defaults model dropdown to Gemini 2.5 Flash', () => {
         const select = screen.getByTestId('model-select') as HTMLSelectElement;
-        expect(select.value).toBe('gemini-2.0-flash');
+        expect(select.value).toBe('gemini-2.5-flash');
       });
 
       it('shows a textarea for custom prompt directions', () => {
@@ -378,8 +378,8 @@ describe('SessionStudentPane', () => {
 
       const call = mockAnalyze.mock.calls[0];
       expect(call[0]).toBe('session-123');
-      // model should default to gemini-2.0-flash
-      expect(call[1]).toBe('gemini-2.0-flash');
+      // model should default to gemini-2.5-flash
+      expect(call[1]).toBe('gemini-2.5-flash');
       // customPrompt should be the default directions string (non-empty)
       expect(typeof call[2]).toBe('string');
       expect(call[2].length).toBeGreaterThan(0);

--- a/frontend/src/app/(app)/instructor/hooks/__tests__/useAnalysisGroups.test.tsx
+++ b/frontend/src/app/(app)/instructor/hooks/__tests__/useAnalysisGroups.test.tsx
@@ -117,10 +117,10 @@ describe('useAnalysisGroups', () => {
       const { result } = renderHook(() => useAnalysisGroups());
 
       await act(async () => {
-        await result.current.analyze('session-1', 'gemini-2.0-flash', 'Focus on bugs and misconceptions.');
+        await result.current.analyze('session-1', 'gemini-2.5-flash', 'Focus on bugs and misconceptions.');
       });
 
-      expect(mockAnalyzeSession).toHaveBeenCalledWith('session-1', 'gemini-2.0-flash', 'Focus on bugs and misconceptions.');
+      expect(mockAnalyzeSession).toHaveBeenCalledWith('session-1', 'gemini-2.5-flash', 'Focus on bugs and misconceptions.');
     });
 
     it('analyze() does NOT send student_id or code to the API', async () => {
@@ -130,7 +130,7 @@ describe('useAnalysisGroups', () => {
       const { result } = renderHook(() => useAnalysisGroups());
 
       await act(async () => {
-        await result.current.analyze('session-1', 'gemini-2.0-flash', 'custom prompt');
+        await result.current.analyze('session-1', 'gemini-2.5-flash', 'custom prompt');
       });
 
       // The mock call should have exactly 3 args: sessionId, model, customPrompt

--- a/frontend/src/lib/api/__tests__/sessions.test.ts
+++ b/frontend/src/lib/api/__tests__/sessions.test.ts
@@ -349,10 +349,10 @@ describe('lib/api/sessions', () => {
       };
       mockApiPost.mockResolvedValue(fakeAnalysis);
 
-      const result = await analyzeSession('sess-1', 'gemini-2.0-flash', 'Focus on actual bugs');
+      const result = await analyzeSession('sess-1', 'gemini-2.5-flash', 'Focus on actual bugs');
 
       expect(mockApiPost).toHaveBeenCalledWith('/sessions/sess-1/analyze', {
-        model: 'gemini-2.0-flash',
+        model: 'gemini-2.5-flash',
         custom_prompt: 'Focus on actual bugs',
       });
       expect(result).toEqual(fakeAnalysis);

--- a/go-backend/internal/ai/gemini.go
+++ b/go-backend/internal/ai/gemini.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/genai"
 )
 
-const defaultModel = "gemini-2.0-flash"
+const defaultModel = "gemini-2.5-flash"
 
 // contentGenerator is a thin interface around the genai SDK's GenerateContent call.
 // It exists so that AnalyzeCode can be unit-tested without making real network calls.


### PR DESCRIPTION
## Summary
- Google deprecated the `gemini-2.0-flash` model, causing 500 errors on the analyze sessions endpoint (`POST /sessions/{id}/analyze`)
- Updated default model to `gemini-2.5-flash` in both backend and frontend
- Removed the deprecated `gemini-2.0-flash` option from the instructor model dropdown

## Changes
- `go-backend/internal/ai/gemini.go`: Updated `defaultModel` constant
- `frontend/.../SessionStudentPane.tsx`: Updated `DEFAULT_MODEL` constant, removed deprecated dropdown option
- Updated all affected frontend tests

## Test plan
- [x] `make test-api` passes
- [x] `make lint-api` passes
- [x] `make test-frontend` passes (2,298 tests)
- [x] `make lint-frontend` passes
- [x] `make typecheck-frontend` passes

Beads: PLAT-4ue7

Generated with Claude Code