### PR TITLE
chore: sync analyze prompt with upstream coding-tool version

### DIFF
--- a/frontend/src/app/(app)/instructor/components/SessionStudentPane.tsx
+++ b/frontend/src/app/(app)/instructor/components/SessionStudentPane.tsx
@@ -22,16 +22,20 @@ const DEFAULT_MODEL = 'gemini-2.5-flash';
 // When the instructor clicks Analyze without editing, this is exactly what the backend uses.
 // Keeping them in sync ensures the pre-filled UI text reflects actual backend behavior.
 const DEFAULT_PROMPT =
-  `Identify patterns across all student submissions. Group students by common mistakes or approaches.\n\n` +
-  `Bucket guidelines:\n` +
+  `Identify distinct bugs, misconceptions, or patterns across all student submissions. Group students by issue. A student can appear in multiple issues. Order issues by frequency (most common first).\n\n` +
+  `Also classify each student as either finished (code appears complete and correct) or in-progress (still working, has bugs, or incomplete). Include finished student IDs in finished_student_ids.\n\n` +
+  `Severity guidelines:\n` +
   `- "error": A logical or correctness bug (e.g., off-by-one, wrong operator, incorrect algorithm)\n` +
   `- "misconception": A conceptual misunderstanding (e.g., confusing iteration with recursion, wrong mental model)\n` +
   `- "style": A code quality concern that does not affect correctness (e.g., redundant variable, unclear naming)\n` +
   `- "good-pattern": A positive practice worth highlighting to the class\n\n` +
   `Constraints:\n` +
-  `- Return at most 5 issues total across all buckets.\n` +
+  `- Be CONCISE — instructor reads this live during lecture.\n` +
+  `- Maximum 5 issues. Only include issues that are pedagogically interesting.\n` +
+  `- Title: short (3-8 words).\n` +
+  `- Explanation: one sentence, actionable.\n` +
   `- Each issue must have at least 1 student.\n` +
-  `- Do not create a bucket for students who have not attempted the problem or submitted empty code — omit them from issue buckets and include their IDs in finished_student_ids if their code is complete, or exclude them from all lists if it is empty.\n` +
+  `- Omit students with empty or unmodified starter code from issue lists.\n` +
   `- Set overall_note to a 1-2 sentence summary of the class's performance.`;
 
 interface SessionStudentPaneProps {

--- a/frontend/src/app/(app)/instructor/components/__tests__/SessionStudentPane.test.tsx
+++ b/frontend/src/app/(app)/instructor/components/__tests__/SessionStudentPane.test.tsx
@@ -320,7 +320,7 @@ describe('SessionStudentPane', () => {
         const textarea = screen.getByTestId('custom-prompt-textarea') as HTMLTextAreaElement;
         // Must match the backend DefaultCustomDirections — not the old shorter frontend-only string.
         // This ensures what the instructor sees pre-filled is exactly what the backend uses.
-        expect(textarea.value).toContain('Identify patterns across all student submissions');
+        expect(textarea.value).toContain('Identify distinct bugs, misconceptions, or patterns across all student submissions');
         // Must NOT contain the old short frontend-only default that differs from backend
         expect(textarea.value).not.toContain('Focus on actual bugs');
       });

--- a/go-backend/internal/ai/prompt.go
+++ b/go-backend/internal/ai/prompt.go
@@ -7,18 +7,23 @@ import (
 
 // DefaultCustomDirections is the default instructor-editable prompt section.
 // Instructors can override this to adjust how the AI categorizes student work.
-const DefaultCustomDirections = `Identify patterns across all student submissions. Group students by common mistakes or approaches.
+const DefaultCustomDirections = `Identify distinct bugs, misconceptions, or patterns across all student submissions. Group students by issue. A student can appear in multiple issues. Order issues by frequency (most common first).
 
-Bucket guidelines:
+Also classify each student as either finished (code appears complete and correct) or in-progress (still working, has bugs, or incomplete). Include finished student IDs in finished_student_ids.
+
+Severity guidelines:
 - "error": A logical or correctness bug (e.g., off-by-one, wrong operator, incorrect algorithm)
 - "misconception": A conceptual misunderstanding (e.g., confusing iteration with recursion, wrong mental model)
 - "style": A code quality concern that does not affect correctness (e.g., redundant variable, unclear naming)
 - "good-pattern": A positive practice worth highlighting to the class
 
 Constraints:
-- Return at most 5 issues total across all buckets.
+- Be CONCISE — instructor reads this live during lecture.
+- Maximum 5 issues. Only include issues that are pedagogically interesting.
+- Title: short (3-8 words).
+- Explanation: one sentence, actionable.
 - Each issue must have at least 1 student.
-- Do not create a bucket for students who have not attempted the problem or submitted empty code — omit them from issue buckets and include their IDs in finished_student_ids if their code is complete, or exclude them from all lists if it is empty.
+- Omit students with empty or unmodified starter code from issue lists.
 - Set overall_note to a 1-2 sentence summary of the class's performance.`
 
 // BuildPrompt constructs the full prompt for the AI model from the problem description,
@@ -26,8 +31,7 @@ Constraints:
 func BuildPrompt(problemDescription string, submissions []StudentSubmission, customDirections string) string {
 	var sb strings.Builder
 
-	sb.WriteString("You are an expert programming instructor analyzing student code submissions.\n")
-	sb.WriteString("Your task is to identify common patterns, mistakes, and strengths across the class.\n\n")
+	sb.WriteString("You are an experienced CS instructor analyzing student code submissions for a live classroom walkthrough.\n\n")
 
 	sb.WriteString("## Problem Description\n\n")
 	sb.WriteString(problemDescription)


### PR DESCRIPTION
## Summary
- Synced AI analysis prompt with the more refined upstream version from coding-tool
- Improves prompt quality for live classroom walkthrough use case
- Keeps max 5 issues (upstream uses 10, but 5 is better in practice)

## Changes
- `go-backend/internal/ai/prompt.go`: Updated `DefaultCustomDirections` with conciseness directive, title/explanation guidance, frequency ordering, pedagogical filter, and finished/in-progress classification
- `go-backend/internal/ai/prompt.go`: Updated `BuildPrompt` system message to match upstream tone
- `frontend/.../SessionStudentPane.tsx`: Synced `DEFAULT_PROMPT` to match backend
- `frontend/.../SessionStudentPane.test.tsx`: Updated test assertion for new prompt text

## Test plan
- [x] `make test-api` passes
- [x] `make lint-api` passes
- [x] `make test-frontend` passes (2,298 tests)
- [x] `make lint-frontend` passes

Beads: PLAT-v3hp

Generated with Claude Code