### PR TITLE
feat: add gemini-2.5-flash-lite default and increase analyze timeout

### DIFF
--- a/frontend/src/app/(app)/instructor/components/SessionStudentPane.tsx
+++ b/frontend/src/app/(app)/instructor/components/SessionStudentPane.tsx
@@ -16,7 +16,7 @@ import { Problem, ExecutionSettings } from '@/types/problem';
 import useAnalysisGroups from '../hooks/useAnalysisGroups';
 import { Student, RealtimeStudent, ExecutionResult } from '../types';
 
-const DEFAULT_MODEL = 'gemini-2.5-flash';
+const DEFAULT_MODEL = 'gemini-2.5-flash-lite';
 
 // DEFAULT_PROMPT must match the backend's DefaultCustomDirections in go-backend/internal/ai/prompt.go.
 // When the instructor clicks Analyze without editing, this is exactly what the backend uses.
@@ -239,6 +239,7 @@ export function SessionStudentPane({
                   onChange={e => setSelectedModel(e.target.value)}
                   className="w-full text-sm border border-gray-300 rounded px-2 py-1"
                 >
+                  <option value="gemini-2.5-flash-lite">Gemini 2.5 Flash Lite</option>
                   <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
                 </select>
               </div>

--- a/frontend/src/app/(app)/instructor/components/__tests__/SessionStudentPane.test.tsx
+++ b/frontend/src/app/(app)/instructor/components/__tests__/SessionStudentPane.test.tsx
@@ -300,16 +300,20 @@ describe('SessionStudentPane', () => {
         fireEvent.click(screen.getByTestId('analysis-options-toggle'));
       });
 
-      it('shows a model dropdown with only Gemini 2.5 Flash option (2.0 removed)', () => {
+      it('shows a model dropdown with Gemini 2.5 Flash options (2.0 removed)', () => {
         const select = screen.getByTestId('model-select');
         expect(select).toBeInTheDocument();
         expect(screen.queryByRole('option', { name: /gemini 2\.0 flash/i })).not.toBeInTheDocument();
-        expect(screen.getByRole('option', { name: /gemini 2\.5 flash/i })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /^gemini 2\.5 flash$/i })).toBeInTheDocument();
       });
 
-      it('defaults model dropdown to Gemini 2.5 Flash', () => {
+      it('includes gemini-2.5-flash-lite as a dropdown option', () => {
+        expect(screen.getByRole('option', { name: /gemini 2\.5 flash lite/i })).toBeInTheDocument();
+      });
+
+      it('defaults model dropdown to gemini-2.5-flash-lite', () => {
         const select = screen.getByTestId('model-select') as HTMLSelectElement;
-        expect(select.value).toBe('gemini-2.5-flash');
+        expect(select.value).toBe('gemini-2.5-flash-lite');
       });
 
       it('shows a textarea for custom prompt directions', () => {
@@ -378,8 +382,8 @@ describe('SessionStudentPane', () => {
 
       const call = mockAnalyze.mock.calls[0];
       expect(call[0]).toBe('session-123');
-      // model should default to gemini-2.5-flash
-      expect(call[1]).toBe('gemini-2.5-flash');
+      // model should default to gemini-2.5-flash-lite (faster, cheaper default)
+      expect(call[1]).toBe('gemini-2.5-flash-lite');
       // customPrompt should be the default directions string (non-empty)
       expect(typeof call[2]).toBe('string');
       expect(call[2].length).toBeGreaterThan(0);

--- a/go-backend/internal/ai/gemini.go
+++ b/go-backend/internal/ai/gemini.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/genai"
 )
 
-const defaultModel = "gemini-2.5-flash"
+const defaultModel = "gemini-2.5-flash-lite"
 
 // contentGenerator is a thin interface around the genai SDK's GenerateContent call.
 // It exists so that AnalyzeCode can be unit-tested without making real network calls.

--- a/go-backend/internal/ai/gemini_analyze_test.go
+++ b/go-backend/internal/ai/gemini_analyze_test.go
@@ -371,6 +371,16 @@ func TestAnalyzeCode_DefaultCustomDirectionsUsedWhenEmpty(t *testing.T) {
 	}
 }
 
+// TestDefaultModel_IsFlashLite verifies that the default Gemini model is gemini-2.5-flash-lite.
+// This model is faster and cheaper than gemini-2.5-flash (which is a thinking model),
+// making it more suitable as the default for analyzing large class submissions.
+func TestDefaultModel_IsFlashLite(t *testing.T) {
+	const wantModel = "gemini-2.5-flash-lite"
+	if defaultModel != wantModel {
+		t.Errorf("defaultModel = %q, want %q — update const defaultModel in gemini.go", defaultModel, wantModel)
+	}
+}
+
 // TestBuildResponseSchema_HasRequiredFields verifies that buildResponseSchema returns a schema
 // with the expected top-level required fields.
 func TestBuildResponseSchema_HasRequiredFields(t *testing.T) {

--- a/go-backend/internal/middleware/timeout.go
+++ b/go-backend/internal/middleware/timeout.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// TimeoutOverride replaces any inherited timeout/cancellation with a fresh deadline.
+//
+// Unlike the standard chi middleware.Timeout (which uses context.WithTimeout on the
+// incoming context), this middleware first strips the parent's deadline via
+// context.WithoutCancel, then applies a new deadline. This allows a route group to
+// use a LONGER timeout than a surrounding route group.
+//
+// The handler is responsible for checking ctx.Done() and returning an appropriate
+// error when the context expires. This middleware only sets the deadline; it does
+// not run the handler in a goroutine or forcefully write a timeout response.
+//
+// Use this when a specific route needs more time than the global API timeout.
+// For example, the analyze endpoint may take up to 120 s with large classes,
+// while the global API timeout is 30 s.
+//
+//	r.Group(func(r chi.Router) {
+//	    r.Use(custommw.TimeoutOverride(120 * time.Second))
+//	    r.Post("/sessions/{id}/analyze", analyzeHandler.Analyze)
+//	})
+func TimeoutOverride(d time.Duration) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Strip any parent cancellation/deadline so the new timeout is independent.
+			ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), d)
+			defer cancel()
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/go-backend/internal/middleware/timeout_test.go
+++ b/go-backend/internal/middleware/timeout_test.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestTimeoutOverride_AppliesFreshDeadline verifies that TimeoutOverride replaces
+// the parent context's deadline with a new one, independent of any inherited deadline.
+//
+// This is the key property that distinguishes TimeoutOverride from chi's built-in
+// middleware.Timeout: a child context created with context.WithTimeout cannot extend
+// a parent deadline (Go's context API prevents it), but TimeoutOverride uses
+// context.WithoutCancel to strip the parent deadline first.
+func TestTimeoutOverride_AppliesFreshDeadline(t *testing.T) {
+	const (
+		outerTimeout    = 1 * time.Millisecond
+		overrideTimeout = 5 * time.Millisecond
+		handlerSleep    = 3 * time.Millisecond
+	)
+
+	// Build a handler that sleeps 3ms, then checks if its context is still live.
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(handlerSleep)
+		select {
+		case <-r.Context().Done():
+			w.WriteHeader(http.StatusGatewayTimeout)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	wrapped := TimeoutOverride(overrideTimeout)(innerHandler)
+
+	// Construct a request whose context already has a 1ms deadline (simulating the
+	// global API timeout being applied upstream by the outer router group).
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	shortCtx, shortCancel := context.WithTimeout(req.Context(), outerTimeout)
+	defer shortCancel()
+	req = req.WithContext(shortCtx)
+
+	// Wait for the outer timeout to fully elapse, so the parent context is cancelled.
+	time.Sleep(outerTimeout * 3)
+
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+
+	// The handler slept 3ms; the override timeout is 5ms.
+	// Despite the parent context being cancelled (1ms elapsed), the handler
+	// should complete successfully because TimeoutOverride uses a fresh context.
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 (handler completed within 5ms override), got %d — TimeoutOverride did not replace parent deadline", rr.Code)
+	}
+}
+
+// TestTimeoutOverride_RespectsItsOwnDeadline verifies that TimeoutOverride's own
+// deadline is still enforced (i.e. it does not create an immortal context).
+func TestTimeoutOverride_RespectsItsOwnDeadline(t *testing.T) {
+	const (
+		overrideTimeout = 1 * time.Millisecond
+		handlerSleep    = 5 * time.Millisecond
+	)
+
+	innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(handlerSleep)
+		select {
+		case <-r.Context().Done():
+			w.WriteHeader(http.StatusGatewayTimeout)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	wrapped := TimeoutOverride(overrideTimeout)(innerHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+
+	// Handler sleeps 5ms but override timeout is 1ms — context should be cancelled.
+	// The handler checks ctx.Done() and writes 504 when the deadline expires.
+	if rr.Code == http.StatusOK {
+		t.Errorf("expected non-200 (handler timed out), got 200 — TimeoutOverride not enforcing its own deadline")
+	}
+}

--- a/go-backend/internal/server/analyze_timeout_test.go
+++ b/go-backend/internal/server/analyze_timeout_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	custommw "github.com/jdelfino/eval/go-backend/internal/middleware"
+)
+
+// TestAnalyzeRouteTimeoutOverridesGlobal verifies that the analyze route group
+// applies a timeout longer than the global API timeout using TimeoutOverride.
+//
+// The analyze endpoint can take 30-120s for large classes. The global 30s timeout
+// is applied at the /api/v1 router level. A plain nested middleware.Timeout(120s)
+// would NOT work because context.WithTimeout cannot extend a parent deadline —
+// it can only shorten it. TimeoutOverride uses context.WithoutCancel first to
+// strip the parent deadline before applying the new one.
+//
+// This test uses small synthetic timeouts (1ms global, 5ms analyze-route override)
+// to verify the middleware composition without making the test suite slow.
+// A handler that sleeps for 3ms should:
+//   - timeout on a regular route (only 1ms allowed)
+//   - succeed on the analyze route (5ms override replaces the 1ms deadline)
+func TestAnalyzeRouteTimeoutOverridesGlobal(t *testing.T) {
+	const (
+		globalTimeout   = 1 * time.Millisecond
+		analyzeTimeout  = 5 * time.Millisecond
+		handlerSleep    = 3 * time.Millisecond
+	)
+
+	// Build a router that mirrors the production structure:
+	//   /api/v1 group with global timeout
+	//     /other  — no override; subject to global 1ms timeout
+	//     /analyze group with TimeoutOverride(5ms) — replaces the 1ms deadline
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(middleware.Timeout(globalTimeout))
+
+		// Regular route — no timeout override; will be killed by global timeout.
+		r.Get("/other", func(w http.ResponseWriter, req *http.Request) {
+			time.Sleep(handlerSleep)
+			select {
+			case <-req.Context().Done():
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		})
+
+		// Analyze group — uses TimeoutOverride to replace (not extend) the parent deadline.
+		r.Group(func(r chi.Router) {
+			r.Use(custommw.TimeoutOverride(analyzeTimeout))
+			r.Get("/sessions/{id}/analyze", func(w http.ResponseWriter, req *http.Request) {
+				time.Sleep(handlerSleep)
+				select {
+				case <-req.Context().Done():
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			})
+		})
+	})
+
+	t.Run("regular route times out under global timeout", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/other", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		// The handler sleeps 3ms but the global timeout is 1ms.
+		// The timeout middleware cancels the context; the handler sees ctx.Done()
+		// and returns 503, or the middleware writes 504.
+		// Either way, the response must NOT be 200.
+		if rr.Code == http.StatusOK {
+			t.Errorf("regular route: expected timeout (non-200), got 200 — global timeout not enforced")
+		}
+	})
+
+	t.Run("analyze route succeeds under TimeoutOverride", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/abc/analyze", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		// The handler sleeps 3ms; the analyze-route override is 5ms.
+		// TimeoutOverride replaces the 1ms deadline with a fresh 5ms deadline,
+		// so the handler completes before timing out → must return 200.
+		if rr.Code != http.StatusOK {
+			t.Errorf("analyze route: expected 200 (handler finishes within 5ms override), got %d — TimeoutOverride not working", rr.Code)
+		}
+	})
+}

--- a/go-backend/internal/server/server.go
+++ b/go-backend/internal/server/server.go
@@ -335,6 +335,7 @@ func NewWithRegistry(cfg *config.Config, logger *slog.Logger, pool DatabasePool,
 			}
 			analyzeHandler := handler.NewAnalyzeHandler(aiClient)
 			r.Group(func(r chi.Router) {
+				r.Use(custommw.TimeoutOverride(120 * time.Second))
 				r.Use(custommw.RequirePermission(auth.PermSessionManage))
 				r.With(
 					custommw.ForCategory(rl, "analyzeDaily", custommw.UserKey),


### PR DESCRIPTION
## Summary
- Default Gemini model changed from `gemini-2.5-flash` to `gemini-2.5-flash-lite` (faster, cheaper, sufficient for code grouping)
- Analyze endpoint timeout increased from 30s to 120s via new `TimeoutOverride` middleware
- Frontend model dropdown adds flash-lite as the first (default) option; flash remains selectable

## Changes
- `go-backend/internal/ai/gemini.go` — `defaultModel` constant → `gemini-2.5-flash-lite`
- `go-backend/internal/middleware/timeout.go` — new `TimeoutOverride` middleware using `context.WithoutCancel` to replace parent deadline
- `go-backend/internal/server/server.go` — analyze route group uses `TimeoutOverride(120s)`
- `frontend/.../SessionStudentPane.tsx` — new dropdown option, new default

## Test plan
- [x] Go backend tests pass (`make test-api`)
- [x] Go linting passes (`make lint-api`)
- [x] Frontend tests pass (`make test-frontend`)
- [x] Frontend linting passes (`make lint-frontend`)
- [ ] Manual: trigger analyze on a session with 10+ students — should complete within 120s

Beads: PLAT-tci7

Generated with Claude Code