### PR TITLE
fix: eliminate 5s lefthook delay from bd terminal query timeout

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   parallel: true
   commands:
     bd-pre-commit:
-      run: bd hooks run pre-commit
+      run: TERM=dumb bd hooks run pre-commit
     lint-api:
       glob: "go-backend/{,**/}*.go"
       run: make lint-api
@@ -24,13 +24,13 @@ pre-commit:
 prepare-commit-msg:
   commands:
     bd-trailers:
-      run: bd hooks run prepare-commit-msg {1}
+      run: TERM=dumb bd hooks run prepare-commit-msg {1}
 
 pre-push:
   parallel: true
   commands:
     bd-push:
-      run: bd hooks run pre-push {1} {2}
+      run: TERM=dumb bd hooks run pre-push {1} {2}
     test-api:
       glob: "go-backend/{,**/}*.go"
       run: make test-api
@@ -47,9 +47,9 @@ pre-push:
 post-checkout:
   commands:
     bd-hooks:
-      run: bd hooks run post-checkout {1} {2} {3}
+      run: TERM=dumb bd hooks run post-checkout {1} {2} {3}
 
 post-merge:
   commands:
     bd-hooks:
-      run: bd hooks run post-merge {1}
+      run: TERM=dumb bd hooks run post-merge {1}


### PR DESCRIPTION
## Summary
- bd sends terminal capability queries (cursor position, window title) that time out after 5s inside lefthook's PTY output capture
- Adding `TERM=dumb` to all bd commands in lefthook.yml suppresses the queries

## Changes
- `lefthook.yml` — prefix all `bd hooks run` commands with `TERM=dumb`

## Before/After
- post-checkout: 5.05s → 0.09s
- post-merge: 5.34s → 0.37s
- pre-commit (bd): 5.42s → 0.04s
- prepare-commit-msg: 5.06s → 0.04s
- pre-push (bd): 5.13s → 0.10s

Beads: PLAT-mtwr

Generated with Claude Code