### PR TITLE
fix: add health polling to executor smoke test

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -168,8 +168,20 @@ trap cleanup_smoke_pods EXIT
 read -r -d '' EXECUTOR_TEST_SCRIPT << 'PYEOF' || true
 import urllib.request, json, sys
 
+EXECUTOR_URL = "http://executor:8081"
+
+# Wait for the executor service to become reachable.  After a deploy with
+# strategy=Recreate, the Service endpoints may lag behind the rollout status.
+import time
+for _attempt in range(30):
+    try:
+        urllib.request.urlopen(f"{EXECUTOR_URL}/healthz", timeout=5)
+        break
+    except Exception:
+        time.sleep(2)
+
 def execute(code, timeout_ms=10000):
-    req = urllib.request.Request("http://executor:8081/execute",
+    req = urllib.request.Request(f"{EXECUTOR_URL}/execute",
         data=json.dumps({"code": code, "timeout_ms": timeout_ms}).encode(),
         headers={"Content-Type": "application/json"})
     with urllib.request.urlopen(req, timeout=30) as r:


### PR DESCRIPTION
## Summary
- Add health endpoint polling (up to 60s) before running executor sandbox smoke tests
- Fixes flaky deploy failures caused by Service endpoint propagation lag after Recreate deploys

## Changes
- `scripts/smoke-test.sh`: Poll `executor:8081/healthz` before running sandbox tests, extract executor URL to constant

## Test plan
- [ ] Next deploy with executor changes passes smoke tests reliably
- [ ] Manual: the health poll loop exits immediately when executor is already healthy (no added latency in the common case)

Beads: PLAT-ydyl

Generated with Claude Code