### PR TITLE
fix: delete preview student on exit to clean up session artifacts

### DIFF
--- a/go-backend/internal/handler/preview.go
+++ b/go-backend/internal/handler/preview.go
@@ -133,8 +133,10 @@ func (h *PreviewHandler) EnterPreview(w http.ResponseWriter, r *http.Request) {
 
 // ExitPreview handles DELETE /sections/{section_id}/preview.
 //
-// It unenrolls the preview student from the given section. This is best-effort;
-// errors during unenroll do not fail the request.
+// It deletes the preview student user entirely. Cascade constraints on the users
+// table clean up all related rows (preview_students, section_memberships,
+// session_students, student_work, revisions). This is best-effort; errors during
+// deletion do not fail the request so clients can always clean up local state.
 func (h *PreviewHandler) ExitPreview(w http.ResponseWriter, r *http.Request) {
 	instructor := auth.UserFromContext(r.Context())
 	if instructor == nil {
@@ -142,27 +144,15 @@ func (h *PreviewHandler) ExitPreview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sectionID, ok := httpbind.ParseUUIDParam(w, r, "section_id")
-	if !ok {
+	if _, ok := httpbind.ParseUUIDParam(w, r, "section_id"); !ok {
 		return
 	}
 
-	ps, err := h.previewRepo.GetPreviewStudent(r.Context(), instructor.ID)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			// No preview student — nothing to unenroll. Treat as success.
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		httputil.WriteInternalError(w, r, err, "internal error")
-		return
-	}
-
-	// Best-effort unenroll: errors are logged but do not fail the request so
+	// Best-effort delete: errors are logged but do not fail the request so
 	// clients can always clean up their local state even if the server-side
-	// membership cleanup fails.
-	if err := h.previewRepo.UnenrollPreviewStudent(r.Context(), ps.StudentUserID, sectionID); err != nil {
-		slog.WarnContext(r.Context(), "preview: failed to unenroll preview student (best-effort)", "error", err)
+	// cleanup fails. DeletePreviewStudent is a no-op if no preview student exists.
+	if err := h.previewRepo.DeletePreviewStudent(r.Context(), instructor.ID); err != nil {
+		slog.WarnContext(r.Context(), "preview: failed to delete preview student (best-effort)", "error", err)
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/go-backend/internal/handler/preview_test.go
+++ b/go-backend/internal/handler/preview_test.go
@@ -23,6 +23,7 @@ type mockPreviewRepo struct {
 	enrollPreviewStudentFn                    func(ctx context.Context, studentUserID uuid.UUID, sectionID uuid.UUID) error
 	unenrollPreviewStudentFromOtherSectionsFn func(ctx context.Context, studentUserID uuid.UUID, keepSectionID uuid.UUID) error
 	unenrollPreviewStudentFn                  func(ctx context.Context, studentUserID uuid.UUID, sectionID uuid.UUID) error
+	deletePreviewStudentFn                    func(ctx context.Context, instructorID uuid.UUID) error
 }
 
 func (m *mockPreviewRepo) GetPreviewStudent(ctx context.Context, instructorID uuid.UUID) (*store.PreviewStudent, error) {
@@ -59,6 +60,13 @@ func (m *mockPreviewRepo) UnenrollPreviewStudent(ctx context.Context, studentUse
 		return m.unenrollPreviewStudentFn(ctx, studentUserID, sectionID)
 	}
 	panic("mockPreviewRepo: unexpected UnenrollPreviewStudent call")
+}
+
+func (m *mockPreviewRepo) DeletePreviewStudent(ctx context.Context, instructorID uuid.UUID) error {
+	if m.deletePreviewStudentFn != nil {
+		return m.deletePreviewStudentFn(ctx, instructorID)
+	}
+	panic("mockPreviewRepo: unexpected DeletePreviewStudent call")
 }
 
 // --- previewTestRepos: overrides GetSection for defense-in-depth check ---
@@ -454,26 +462,13 @@ func TestEnterPreview_EnrollError(t *testing.T) {
 func TestExitPreview_Success(t *testing.T) {
 	instructorID := uuid.New()
 	sectionID := uuid.New()
-	studentUserID := uuid.New()
 
-	unenrollCalled := false
+	deleteCalled := false
 	repo := &mockPreviewRepo{
-		getPreviewStudentFn: func(_ context.Context, id uuid.UUID) (*store.PreviewStudent, error) {
+		deletePreviewStudentFn: func(_ context.Context, id uuid.UUID) error {
+			deleteCalled = true
 			if id != instructorID {
-				t.Fatalf("unexpected instructorID: %v", id)
-			}
-			return &store.PreviewStudent{
-				InstructorID:  instructorID,
-				StudentUserID: studentUserID,
-			}, nil
-		},
-		unenrollPreviewStudentFn: func(_ context.Context, stuID, secID uuid.UUID) error {
-			unenrollCalled = true
-			if stuID != studentUserID {
-				t.Errorf("unenroll: unexpected studentUserID: %v", stuID)
-			}
-			if secID != sectionID {
-				t.Errorf("unenroll: unexpected sectionID: %v", secID)
+				t.Errorf("delete: unexpected instructorID: %v", id)
 			}
 			return nil
 		},
@@ -495,8 +490,8 @@ func TestExitPreview_Success(t *testing.T) {
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if !unenrollCalled {
-		t.Error("UnenrollPreviewStudent should have been called")
+	if !deleteCalled {
+		t.Error("DeletePreviewStudent should have been called")
 	}
 }
 
@@ -537,11 +532,12 @@ func TestExitPreview_InvalidSectionID(t *testing.T) {
 	}
 }
 
-func TestExitPreview_PreviewStudentNotFound(t *testing.T) {
+func TestExitPreview_NoPreviewStudent(t *testing.T) {
 	sectionID := uuid.New()
 	repo := &mockPreviewRepo{
-		getPreviewStudentFn: func(_ context.Context, _ uuid.UUID) (*store.PreviewStudent, error) {
-			return nil, store.ErrNotFound
+		deletePreviewStudentFn: func(_ context.Context, _ uuid.UUID) error {
+			// No-op — no preview student exists, DELETE affects 0 rows
+			return nil
 		},
 	}
 
@@ -558,52 +554,16 @@ func TestExitPreview_PreviewStudentNotFound(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ExitPreview(rec, req)
 
-	// If no preview student exists, exit is a no-op (204)
+	// If no preview student exists, delete is a no-op (204)
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("expected 204 (no-op when no preview student), got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestExitPreview_GetPreviewStudentError(t *testing.T) {
+func TestExitPreview_DeleteError_BestEffort(t *testing.T) {
 	sectionID := uuid.New()
 	repo := &mockPreviewRepo{
-		getPreviewStudentFn: func(_ context.Context, _ uuid.UUID) (*store.PreviewStudent, error) {
-			return nil, errors.New("db error")
-		},
-	}
-
-	h := NewPreviewHandler(repo)
-	req := httptest.NewRequest(http.MethodDelete, "/sections/"+sectionID.String()+"/preview", nil)
-	req = req.WithContext(withChiParam(req.Context(), "section_id", sectionID.String()))
-	ctx := auth.WithUser(req.Context(), &auth.User{
-		ID:          uuid.New(),
-		Role:        auth.RoleInstructor,
-		NamespaceID: "test-ns",
-	})
-	req = req.WithContext(ctx)
-
-	rec := httptest.NewRecorder()
-	h.ExitPreview(rec, req)
-
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d: %s", rec.Code, rec.Body.String())
-	}
-}
-
-// TestExitPreview_UnenrollBestEffort verifies that unenroll errors don't fail the request (best-effort).
-func TestExitPreview_UnenrollBestEffort(t *testing.T) {
-	instructorID := uuid.New()
-	sectionID := uuid.New()
-	studentUserID := uuid.New()
-
-	repo := &mockPreviewRepo{
-		getPreviewStudentFn: func(_ context.Context, _ uuid.UUID) (*store.PreviewStudent, error) {
-			return &store.PreviewStudent{
-				InstructorID:  instructorID,
-				StudentUserID: studentUserID,
-			}, nil
-		},
-		unenrollPreviewStudentFn: func(_ context.Context, _, _ uuid.UUID) error {
+		deletePreviewStudentFn: func(_ context.Context, _ uuid.UUID) error {
 			return errors.New("db error")
 		},
 	}
@@ -612,7 +572,7 @@ func TestExitPreview_UnenrollBestEffort(t *testing.T) {
 	req := httptest.NewRequest(http.MethodDelete, "/sections/"+sectionID.String()+"/preview", nil)
 	req = req.WithContext(withChiParam(req.Context(), "section_id", sectionID.String()))
 	ctx := auth.WithUser(req.Context(), &auth.User{
-		ID:          instructorID,
+		ID:          uuid.New(),
 		Role:        auth.RoleInstructor,
 		NamespaceID: "test-ns",
 	})
@@ -621,11 +581,12 @@ func TestExitPreview_UnenrollBestEffort(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ExitPreview(rec, req)
 
-	// Unenroll is best-effort, still returns 204
+	// Delete is best-effort, still returns 204
 	if rec.Code != http.StatusNoContent {
-		t.Fatalf("expected 204 (unenroll is best-effort), got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("expected 204 (delete is best-effort), got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
 
 // --- WriteInternalError logging: underlying error must be logged for all 500 paths ---
 
@@ -945,10 +906,10 @@ func TestEnterPreview_UnenrollOtherSectionsError_Logged(t *testing.T) {
 	}
 }
 
-// TestExitPreview_UnenrollError_Logged verifies that when UnenrollPreviewStudent
+// TestExitPreview_DeleteError_Logged verifies that when DeletePreviewStudent
 // fails in ExitPreview, the error is logged as a warning (not silently dropped)
 // and the request still succeeds (best-effort).
-func TestExitPreview_UnenrollError_Logged(t *testing.T) {
+func TestExitPreview_DeleteError_Logged(t *testing.T) {
 	h := &capturingSlogHandler{}
 	orig := slog.Default()
 	slog.SetDefault(slog.New(h))
@@ -956,18 +917,11 @@ func TestExitPreview_UnenrollError_Logged(t *testing.T) {
 
 	instructorID := uuid.New()
 	sectionID := uuid.New()
-	studentUserID := uuid.New()
-	unenrollErr := fmt.Errorf("db: connection lost from ExitPreview UnenrollPreviewStudent")
+	deleteErr := fmt.Errorf("db: connection lost from ExitPreview DeletePreviewStudent")
 
 	repo := &mockPreviewRepo{
-		getPreviewStudentFn: func(_ context.Context, _ uuid.UUID) (*store.PreviewStudent, error) {
-			return &store.PreviewStudent{
-				InstructorID:  instructorID,
-				StudentUserID: studentUserID,
-			}, nil
-		},
-		unenrollPreviewStudentFn: func(_ context.Context, _, _ uuid.UUID) error {
-			return unenrollErr
+		deletePreviewStudentFn: func(_ context.Context, _ uuid.UUID) error {
+			return deleteErr
 		},
 	}
 
@@ -986,48 +940,11 @@ func TestExitPreview_UnenrollError_Logged(t *testing.T) {
 
 	// Still succeeds — best-effort
 	if rec.Code != http.StatusNoContent {
-		t.Fatalf("expected 204 (unenroll is best-effort), got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("expected 204 (delete is best-effort), got %d: %s", rec.Code, rec.Body.String())
 	}
 	// But the error must be logged
-	if !h.containsErrorAttr("connection lost from ExitPreview UnenrollPreviewStudent") {
-		t.Error("expected unenroll error to be logged as warn, but not found in slog output")
+	if !h.containsErrorAttr("connection lost from ExitPreview DeletePreviewStudent") {
+		t.Error("expected delete error to be logged as warn, but not found in slog output")
 	}
 }
 
-// TestExitPreview_GetPreviewStudentError_LogsUnderlyingError verifies that when
-// GetPreviewStudent fails in ExitPreview, WriteInternalError is used.
-func TestExitPreview_GetPreviewStudentError_LogsUnderlyingError(t *testing.T) {
-	h := &capturingSlogHandler{}
-	orig := slog.Default()
-	slog.SetDefault(slog.New(h))
-	t.Cleanup(func() { slog.SetDefault(orig) })
-
-	sectionID := uuid.New()
-	underlyingErr := fmt.Errorf("db: connection reset from ExitPreview GetPreviewStudent")
-
-	repo := &mockPreviewRepo{
-		getPreviewStudentFn: func(_ context.Context, _ uuid.UUID) (*store.PreviewStudent, error) {
-			return nil, underlyingErr
-		},
-	}
-
-	h2 := NewPreviewHandler(repo)
-	req := httptest.NewRequest(http.MethodDelete, "/sections/"+sectionID.String()+"/preview", nil)
-	req = req.WithContext(withChiParam(req.Context(), "section_id", sectionID.String()))
-	ctx := auth.WithUser(req.Context(), &auth.User{
-		ID:          uuid.New(),
-		Role:        auth.RoleInstructor,
-		NamespaceID: "test-ns",
-	})
-	req = req.WithContext(ctx)
-
-	rec := httptest.NewRecorder()
-	h2.ExitPreview(rec, req)
-
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d: %s", rec.Code, rec.Body.String())
-	}
-	if !h.containsErrorAttr("connection reset from ExitPreview GetPreviewStudent") {
-		t.Error("expected underlying error to be logged via WriteInternalError, but it was not found in slog output; use WriteInternalError instead of WriteError")
-	}
-}

--- a/go-backend/internal/middleware/preview_test.go
+++ b/go-backend/internal/middleware/preview_test.go
@@ -14,11 +14,12 @@ import (
 
 // mockPreviewRepo implements store.PreviewRepository for testing.
 type mockPreviewRepo struct {
-	getPreviewStudentFn                     func(ctx context.Context, instructorID uuid.UUID) (*store.PreviewStudent, error)
-	createPreviewStudentFn                  func(ctx context.Context, instructorID uuid.UUID, namespaceID string) (*store.PreviewStudent, error)
-	enrollPreviewStudentFn                  func(ctx context.Context, studentUserID uuid.UUID, sectionID uuid.UUID) error
+	getPreviewStudentFn                       func(ctx context.Context, instructorID uuid.UUID) (*store.PreviewStudent, error)
+	createPreviewStudentFn                    func(ctx context.Context, instructorID uuid.UUID, namespaceID string) (*store.PreviewStudent, error)
+	enrollPreviewStudentFn                    func(ctx context.Context, studentUserID uuid.UUID, sectionID uuid.UUID) error
 	unenrollPreviewStudentFromOtherSectionsFn func(ctx context.Context, studentUserID uuid.UUID, keepSectionID uuid.UUID) error
-	unenrollPreviewStudentFn                func(ctx context.Context, studentUserID uuid.UUID, sectionID uuid.UUID) error
+	unenrollPreviewStudentFn                  func(ctx context.Context, studentUserID uuid.UUID, sectionID uuid.UUID) error
+	deletePreviewStudentFn                    func(ctx context.Context, instructorID uuid.UUID) error
 }
 
 func (m *mockPreviewRepo) GetPreviewStudent(ctx context.Context, instructorID uuid.UUID) (*store.PreviewStudent, error) {
@@ -39,6 +40,13 @@ func (m *mockPreviewRepo) UnenrollPreviewStudentFromOtherSections(ctx context.Co
 
 func (m *mockPreviewRepo) UnenrollPreviewStudent(ctx context.Context, studentUserID uuid.UUID, sectionID uuid.UUID) error {
 	return m.unenrollPreviewStudentFn(ctx, studentUserID, sectionID)
+}
+
+func (m *mockPreviewRepo) DeletePreviewStudent(ctx context.Context, instructorID uuid.UUID) error {
+	if m.deletePreviewStudentFn != nil {
+		return m.deletePreviewStudentFn(ctx, instructorID)
+	}
+	return nil
 }
 
 // newPreviewMiddlewareRequest creates a test request with the X-Preview-Section header.

--- a/go-backend/internal/store/preview.go
+++ b/go-backend/internal/store/preview.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -42,6 +43,12 @@ type PreviewRepository interface {
 	// UnenrollPreviewStudent removes the preview student from a specific section.
 	// No-op if the student is not enrolled in that section.
 	UnenrollPreviewStudent(ctx context.Context, studentUserID uuid.UUID, sectionID uuid.UUID) error
+
+	// DeletePreviewStudent deletes the preview student user for the given instructor.
+	// Cascade constraints on the users table automatically clean up all related rows
+	// (preview_students, section_memberships, session_students, student_work, revisions).
+	// No-op if the instructor has no preview student.
+	DeletePreviewStudent(ctx context.Context, instructorID uuid.UUID) error
 }
 
 // GetPreviewStudent retrieves the preview student for the given instructor.
@@ -157,6 +164,53 @@ func (s *Store) UnenrollPreviewStudent(ctx context.Context, studentUserID uuid.U
 		studentUserID, sectionID,
 	)
 	return err
+}
+
+// DeletePreviewStudent deletes the preview student user for the given instructor.
+// Within a transaction it:
+//  1. Removes the student from all sessions.participants arrays (not covered by FK cascades)
+//  2. Deletes the user row — ON DELETE CASCADE cleans up preview_students,
+//     section_memberships, session_students, student_work, and revisions.
+//
+// No-op if the instructor has no preview student.
+func (s *Store) DeletePreviewStudent(ctx context.Context, instructorID uuid.UUID) error {
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	// Look up the student user ID so we can scrub the participants arrays.
+	var studentUserID uuid.UUID
+	err = tx.QueryRow(ctx, `
+		SELECT student_user_id FROM preview_students WHERE instructor_id = $1`,
+		instructorID,
+	).Scan(&studentUserID)
+	if errors.Is(HandleNotFound(err), ErrNotFound) {
+		// No preview student — nothing to delete.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("lookup preview student: %w", err)
+	}
+
+	// Remove from all sessions.participants arrays.
+	_, err = tx.Exec(ctx, `
+		UPDATE sessions SET participants = array_remove(participants, $1)
+		WHERE $1 = ANY(participants)`,
+		studentUserID,
+	)
+	if err != nil {
+		return fmt.Errorf("remove from participants: %w", err)
+	}
+
+	// Delete the user — cascades handle all FK references.
+	_, err = tx.Exec(ctx, `DELETE FROM users WHERE id = $1`, studentUserID)
+	if err != nil {
+		return fmt.Errorf("delete user: %w", err)
+	}
+
+	return tx.Commit(ctx)
 }
 
 // Compile-time check that Store implements PreviewRepository.


### PR DESCRIPTION
## Summary
- **Bug:** After exiting student preview, the preview account still appeared in connected students for live sessions
- **Root cause:** `ExitPreview` only removed the preview student from `section_memberships` but left `session_students` rows and `sessions.participants` entries intact
- **Fix:** `ExitPreview` now deletes the preview student user entirely. CASCADE constraints clean up all FK references; `sessions.participants` array is explicitly scrubbed in the same transaction

## Changes
- Added `DeletePreviewStudent` to `PreviewRepository` interface and `Store` implementation
- `ExitPreview` handler calls `DeletePreviewStudent` (best-effort) instead of `UnenrollPreviewStudent`
- Updated handler and middleware tests to match new behavior

## Test plan
- [x] All handler unit tests pass (including new delete-specific tests)
- [x] All Go backend tests pass with race detector
- [x] Manual: enter preview → join live session → exit preview → verify student no longer in connected list

Beads: PLAT-bjra

Generated with Claude Code