### PR TITLE
fix: remove duplicate /api/v1 prefix in error-reporting API path

### DIFF
--- a/frontend/src/__tests__/contract/error-reporting.integration.test.ts
+++ b/frontend/src/__tests__/contract/error-reporting.integration.test.ts
@@ -36,7 +36,7 @@ describe('reportError()', () => {
     // Call the endpoint directly with apiFetch to verify the actual HTTP status code.
     // reportError() swallows all errors so it cannot distinguish a working endpoint
     // from a broken one — this test fills that gap.
-    const response = await apiFetch('/api/v1/client-errors', {
+    const response = await apiFetch('/client-errors', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/frontend/src/lib/api/__tests__/error-reporting.test.ts
+++ b/frontend/src/lib/api/__tests__/error-reporting.test.ts
@@ -16,7 +16,7 @@ describe('reportError', () => {
     jest.clearAllMocks();
   });
 
-  it('posts to /api/v1/client-errors with error details', async () => {
+  it('posts to /client-errors with error details', async () => {
     mockApiFetch.mockResolvedValue({ ok: true });
 
     const error = new Error('Something broke');
@@ -25,7 +25,7 @@ describe('reportError', () => {
     await reportError(error);
 
     expect(mockApiFetch).toHaveBeenCalledWith(
-      '/api/v1/client-errors',
+      '/client-errors',
       expect.objectContaining({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/lib/api/error-reporting.ts
+++ b/frontend/src/lib/api/error-reporting.ts
@@ -10,7 +10,7 @@ import { apiFetch } from '@/lib/api-client';
 
 /**
  * Reports a client-side error to the backend.
- * Posts to POST /api/v1/client-errors.
+ * Posts to /client-errors (resolved to POST /api/v1/client-errors via BASE_URL).
  * Swallows all failures silently — never throws.
  *
  * @param error - The Error to report
@@ -21,7 +21,7 @@ export async function reportError(
   context?: Record<string, string>
 ): Promise<void> {
   try {
-    await apiFetch('/api/v1/client-errors', {
+    await apiFetch('/client-errors', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- `reportError()` and its contract test passed `/api/v1/client-errors` to `apiFetch()`, but `apiFetch` already prepends `BASE_URL` which includes `/api/v1` — resulting in a doubled path (`/api/v1/api/v1/client-errors`) that returns 404
- Changed all three call sites to use `/client-errors`, consistent with every other API client in the codebase

## Changes
- `frontend/src/lib/api/error-reporting.ts` — fix path from `/api/v1/client-errors` to `/client-errors`
- `frontend/src/lib/api/__tests__/error-reporting.test.ts` — update unit test assertion to match
- `frontend/src/__tests__/contract/error-reporting.integration.test.ts` — fix direct `apiFetch` call path

## Test plan
- [x] Unit tests pass (165 suites, 2419 tests)
- [x] Pre-commit hooks pass (lint, typecheck, api-imports)
- [x] Pre-push hooks pass (tests, contract coverage)
- [ ] Contract tests pass against running backend (CI)

Beads: PLAT-5lsz

Generated with Claude Code