### PR TITLE
docs: add fix-on-branch triage path to coordinator skill

### DIFF
--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -33,6 +33,10 @@ Create a beads issue first:
 bd create "<description>" -t <task|bug|feature> -p 2 --json
 ```
 
+### 2. Check for Existing Branch
+
+If the issue is a fix for code on an existing feature branch (e.g., CI failure on an open PR, `discovered-from` dependency on an issue labeled `in-pr`, or the code to fix doesn't exist on `main`), use that branch as the base in Branch Mode instead of `origin/main`. Commit directly to it — do not create a new branch or PR.
+
 ---
 
 ## Branch Mode
@@ -239,6 +243,7 @@ EOF
 ## Anti-Patterns
 
 - Committing directly to main (branch is protected — all changes require a PR)
+- Creating a new branch/PR for a fix that belongs on an existing feature branch
 - Starting dependent task before blocker is closed
 - Creating PR before running specialized reviews
 - Creating PR with failing tests


### PR DESCRIPTION
## Summary
- Adds a "Detect Fix-on-Branch" triage step to the coordinator skill
- When an issue targets code on an existing feature branch (detected via `discovered-from` deps with `in-pr` labels), the coordinator now commits directly to that branch instead of creating a redundant new branch and PR
- Adds corresponding anti-pattern entry

## Context
Discovered when working PLAT-5lsz — the coordinator created a separate branch/PR for a bug fix that belonged on `feature/observability`, because the skill had no path for "fix code on an existing branch."

## Test plan
- [ ] Human review of skill instructions

Beads: n/a (skill improvement, no tracked issue)

Generated with Claude Code