### PR TITLE
fix: increase timeout margins in flaky TestAnalyzeRouteTimeoutOverridesGlobal

### DIFF
--- a/go-backend/internal/server/analyze_timeout_test.go
+++ b/go-backend/internal/server/analyze_timeout_test.go
@@ -21,22 +21,25 @@ import (
 // it can only shorten it. TimeoutOverride uses context.WithoutCancel first to
 // strip the parent deadline before applying the new one.
 //
-// This test uses small synthetic timeouts (1ms global, 5ms analyze-route override)
+// This test uses small synthetic timeouts (10ms global, 100ms analyze-route override)
 // to verify the middleware composition without making the test suite slow.
-// A handler that sleeps for 3ms should:
-//   - timeout on a regular route (only 1ms allowed)
-//   - succeed on the analyze route (5ms override replaces the 1ms deadline)
+// A handler that sleeps for 50ms should:
+//   - timeout on a regular route (only 10ms allowed)
+//   - succeed on the analyze route (100ms override replaces the 10ms deadline)
+//
+// The timing margins are intentionally generous (10x ratio) to avoid flakiness
+// under CPU contention (e.g. parallel pre-push hooks running multiple test suites).
 func TestAnalyzeRouteTimeoutOverridesGlobal(t *testing.T) {
 	const (
-		globalTimeout   = 1 * time.Millisecond
-		analyzeTimeout  = 5 * time.Millisecond
-		handlerSleep    = 3 * time.Millisecond
+		globalTimeout  = 10 * time.Millisecond
+		analyzeTimeout = 100 * time.Millisecond
+		handlerSleep   = 50 * time.Millisecond
 	)
 
 	// Build a router that mirrors the production structure:
 	//   /api/v1 group with global timeout
-	//     /other  — no override; subject to global 1ms timeout
-	//     /analyze group with TimeoutOverride(5ms) — replaces the 1ms deadline
+	//     /other  — no override; subject to global 10ms timeout
+	//     /analyze group with TimeoutOverride(100ms) — replaces the 10ms deadline
 	r := chi.NewRouter()
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(middleware.Timeout(globalTimeout))
@@ -73,7 +76,7 @@ func TestAnalyzeRouteTimeoutOverridesGlobal(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/other", nil)
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
-		// The handler sleeps 3ms but the global timeout is 1ms.
+		// The handler sleeps 50ms but the global timeout is 10ms.
 		// The timeout middleware cancels the context; the handler sees ctx.Done()
 		// and returns 503, or the middleware writes 504.
 		// Either way, the response must NOT be 200.
@@ -86,11 +89,11 @@ func TestAnalyzeRouteTimeoutOverridesGlobal(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/abc/analyze", nil)
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
-		// The handler sleeps 3ms; the analyze-route override is 5ms.
-		// TimeoutOverride replaces the 1ms deadline with a fresh 5ms deadline,
+		// The handler sleeps 50ms; the analyze-route override is 100ms.
+		// TimeoutOverride replaces the 10ms deadline with a fresh 100ms deadline,
 		// so the handler completes before timing out → must return 200.
 		if rr.Code != http.StatusOK {
-			t.Errorf("analyze route: expected 200 (handler finishes within 5ms override), got %d — TimeoutOverride not working", rr.Code)
+			t.Errorf("analyze route: expected 200 (handler finishes within 100ms override), got %d — TimeoutOverride not working", rr.Code)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Increased timeout margins in TestAnalyzeRouteTimeoutOverridesGlobal from 1ms/5ms/3ms to 10ms/100ms/50ms
- The test was flaky under CPU contention (e.g. parallel pre-push hooks) because the 5ms override left only 2ms of margin for handler execution

## Changes
- `go-backend/internal/server/analyze_timeout_test.go`: bumped globalTimeout (1ms→10ms), analyzeTimeout (5ms→100ms), handlerSleep (3ms→50ms)
- Updated all comments to reflect new values
- Added note explaining the generous margins are intentional for load resilience

## Test plan
- [x] Test passes 10/10 under `go test -race -run TestAnalyzeRouteTimeoutOverridesGlobal -count=10`
- [x] Full `make test-api` passes

Beads: PLAT-hogk

Generated with Claude Code