### PR TITLE
feat(ci): skip executor build-push when code unchanged (PLAT-jlyb)

### DIFF
--- a/.github/workflows/deploy-pipeline.yaml
+++ b/.github/workflows/deploy-pipeline.yaml
@@ -46,11 +46,44 @@ jobs:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
       - run: gcloud auth configure-docker us-east1-docker.pkg.dev
-      - run: |
+      - name: Compute content hash of executor build inputs
+        run: |
+          # Hash all files in executor/ (excluding tmp/) and pkg/ — the only
+          # repo directories COPYed into the Dockerfile. Truncate to 16 chars.
+          HASH=$(find executor/ pkg/ -type f -not -path 'executor/tmp/*' \
+            | sort | xargs sha256sum | sha256sum | cut -c1-16)
+          echo "CONTENT_HASH=$HASH" >> "$GITHUB_ENV"
+          echo "Content hash: $HASH"
+      - name: Check for existing content-addressed image
+        run: |
+          EXISTING=$(gcloud artifacts docker tags list $REGISTRY/executor \
+            --filter="tag:content-$CONTENT_HASH" \
+            --format="value(tag)" 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            echo "CACHE_HIT=true" >> "$GITHUB_ENV"
+            echo "Cache hit: $REGISTRY/executor:content-$CONTENT_HASH already exists"
+          else
+            echo "CACHE_HIT=false" >> "$GITHUB_ENV"
+            echo "Cache miss: building new image"
+          fi
+      - name: Retag existing image (cache hit)
+        if: env.CACHE_HIT == 'true'
+        run: |
+          gcloud artifacts docker tags add \
+            $REGISTRY/executor:content-$CONTENT_HASH \
+            $REGISTRY/executor:${{ github.sha }}
+          gcloud artifacts docker tags add \
+            $REGISTRY/executor:content-$CONTENT_HASH \
+            $REGISTRY/executor:latest
+      - name: Build and push new image (cache miss)
+        if: env.CACHE_HIT == 'false'
+        run: |
           docker build -f executor/Dockerfile \
+            -t $REGISTRY/executor:content-$CONTENT_HASH \
             -t $REGISTRY/executor:${{ github.sha }} \
             -t $REGISTRY/executor:latest \
             .
+          docker push $REGISTRY/executor:content-$CONTENT_HASH
           docker push $REGISTRY/executor:${{ github.sha }}
           docker push $REGISTRY/executor:latest
 

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,13 @@ test-run-e2e-tests:
 validate-ci-workflow:
 	python3 scripts/validate-ci-workflow.py
 
+# Deploy pipeline validation
+# ──────────────────────────────────────────────
+.PHONY: validate-deploy-pipeline
+
+validate-deploy-pipeline:
+	python3 scripts/validate-deploy-pipeline.py
+
 # ──────────────────────────────────────────────
 # Smoke tests (post-deploy)
 # ──────────────────────────────────────────────

--- a/scripts/validate-deploy-pipeline.py
+++ b/scripts/validate-deploy-pipeline.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Validates the structure of .github/workflows/deploy-pipeline.yaml.
+
+Checks that:
+- All required jobs are present
+- build-push-executor uses content-hash caching to skip unnecessary builds
+- The skip path produces a commit-SHA tag (so deploy-staging works unchanged)
+- The build path also produces commit-SHA and latest tags
+
+Exit code 0 = valid, 1 = invalid.
+"""
+
+import sys
+import yaml
+
+
+def load_workflow(path):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def check(condition, message):
+    if not condition:
+        print(f"FAIL: {message}")
+        return False
+    print(f"PASS: {message}")
+    return True
+
+
+def validate(workflow_path):
+    try:
+        wf = load_workflow(workflow_path)
+    except FileNotFoundError:
+        print(f"FAIL: workflow file not found: {workflow_path}")
+        return False
+    except yaml.YAMLError as e:
+        print(f"FAIL: YAML parse error: {e}")
+        return False
+
+    ok = True
+    jobs = wf.get("jobs", {})
+
+    # ── Required jobs ──────────────────────────────────────────────────────────
+    required_jobs = [
+        "build-push-go-api",
+        "build-push-executor",
+        "build-push-frontend",
+        "build-push-test-runner",
+        "ci",
+        "deploy-staging",
+        "deploy-prod",
+    ]
+    for job in required_jobs:
+        ok &= check(job in jobs, f"job exists: {job}")
+
+    # ── build-push-executor: content-hash caching ─────────────────────────────
+    executor_job = jobs.get("build-push-executor", {})
+    executor_str = str(executor_job)
+
+    # The job must compute a content hash of build inputs
+    ok &= check(
+        "sha256sum" in executor_str,
+        "build-push-executor: computes sha256sum content hash",
+    )
+    ok &= check(
+        "content-" in executor_str,
+        "build-push-executor: uses content-$HASH tag prefix",
+    )
+
+    # Exclude executor/tmp/ from the hash
+    ok &= check(
+        "tmp" in executor_str,
+        "build-push-executor: excludes executor/tmp/ from hash",
+    )
+
+    # Must check if the content-tagged image already exists in Artifact Registry
+    ok &= check(
+        "gcloud artifacts docker tags list" in executor_str,
+        "build-push-executor: checks Artifact Registry for existing content-hash tag",
+    )
+
+    # Both skip and build paths must tag the image with the commit SHA
+    # (deploy-staging uses ${{ github.sha }} to reference the image)
+    ok &= check(
+        "github.sha" in executor_str,
+        "build-push-executor: tags image with github.sha (required by deploy-staging)",
+    )
+
+    # Both paths must also update the latest tag
+    ok &= check(
+        "latest" in executor_str,
+        "build-push-executor: updates latest tag",
+    )
+
+    # Must use gcloud artifacts docker tags add for retag-without-pull path
+    ok &= check(
+        "gcloud artifacts docker tags add" in executor_str,
+        "build-push-executor: uses gcloud artifacts docker tags add to retag without pulling",
+    )
+
+    # ── deploy-staging: gates on all build-push jobs ──────────────────────────
+    staging_job = jobs.get("deploy-staging", {})
+    staging_needs = staging_job.get("needs", [])
+    if isinstance(staging_needs, str):
+        staging_needs = [staging_needs]
+    ok &= check(
+        "build-push-executor" in staging_needs,
+        "deploy-staging needs: build-push-executor",
+    )
+
+    # ── deploy-prod: gates on deploy-staging + ci ─────────────────────────────
+    prod_job = jobs.get("deploy-prod", {})
+    prod_needs = prod_job.get("needs", [])
+    if isinstance(prod_needs, str):
+        prod_needs = [prod_needs]
+    ok &= check("deploy-staging" in prod_needs, "deploy-prod needs: deploy-staging")
+    ok &= check("ci" in prod_needs, "deploy-prod needs: ci")
+
+    return ok
+
+
+if __name__ == "__main__":
+    workflow_path = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else ".github/workflows/deploy-pipeline.yaml"
+    )
+    success = validate(workflow_path)
+    print()
+    if success:
+        print("All checks passed.")
+        sys.exit(0)
+    else:
+        print("Some checks failed.")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- Skip the executor Docker build (~2 min) when `executor/` and `pkg/` haven't changed
- Computes a content hash of build inputs and checks Artifact Registry for an existing image
- On cache hit, retags the existing image with the commit SHA (no Docker pull needed)
- On cache miss, performs the full build with both content-hash and SHA tags

## Changes
- `.github/workflows/deploy-pipeline.yaml` — replaced single-step executor build with 4-step content-hash caching logic
- `scripts/validate-deploy-pipeline.py` — structural validator for the deploy pipeline (17 checks)
- `Makefile` — added `validate-deploy-pipeline` target

## Test plan
- [x] `make validate-deploy-pipeline` passes
- [ ] Deploy pipeline runs successfully on merge (cache miss on first run, then cache hit on subsequent runs with no executor changes)

Beads: PLAT-jlyb

Generated with Claude Code