### PR TITLE
ci: warm Go build cache with -race flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: go-backend/go.sum
-      - name: Warm Go build cache
-        run: go build ./...
+      - name: Warm Go build cache (race-instrumented for downstream test jobs)
+        run: go build -race ./...
         working-directory: go-backend
 
   # ── Frontend test jobs ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- The `build-go-api` cache warming step ran `go build ./...` without `-race`, but downstream `go-api-test` runs with `-race -timeout 5m`
- Race-instrumented build artifacts differ from non-race, so the cache wasn't providing full benefit to the critical-path integration test job
- Adding `-race` to the warm step ensures cached build output matches what test jobs need

## Changes
- `.github/workflows/ci.yml`: `build-go-api` step now runs `go build -race ./...`

## Test plan
- [ ] CI passes (the change only affects cache warming — if it fails, downstream jobs fall back to building from scratch)

Beads: PLAT-3u36

Generated with Claude Code