### PR TITLE
fix(ci): skip :latest retag on executor cache hit

### DIFF
--- a/.github/workflows/deploy-pipeline.yaml
+++ b/.github/workflows/deploy-pipeline.yaml
@@ -72,9 +72,9 @@ jobs:
           gcloud artifacts docker tags add \
             $REGISTRY/executor:content-$CONTENT_HASH \
             $REGISTRY/executor:${{ github.sha }}
-          gcloud artifacts docker tags add \
-            $REGISTRY/executor:content-$CONTENT_HASH \
-            $REGISTRY/executor:latest
+          # Skip :latest — moving an existing tag requires
+          # artifactregistry.tags.delete, which the WIF SA lacks.
+          # :latest already points to the same content (cache hit).
       - name: Build and push new image (cache miss)
         if: env.CACHE_HIT == 'false'
         run: |


### PR DESCRIPTION
## Summary
- Fix deploy pipeline failure caused by missing `artifactregistry.tags.delete` permission when retagging `:latest` on executor cache hit
- On cache hit, `:latest` already points to the same content — only the SHA tag is needed for deploy-staging

## Changes
- Remove `:latest` retag from the cache-hit path in `build-push-executor` job
- Cache-miss path still tags and pushes `:latest` normally (new tag, no delete needed)

## Test plan
- [ ] Deploy pipeline succeeds on next push to main (no more PERMISSION_DENIED)
- [ ] CI e2e tests still find executor via `:latest` (unchanged — tag stays from last cache miss)

Beads: PLAT-fyxx

Generated with Claude Code