### PR TITLE
revert: restore build-go-api to non-race build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: go-backend/go.sum
-      - name: Warm Go build cache (race-instrumented for downstream test jobs)
-        run: go build -race ./...
+      - name: Warm Go build cache
+        run: go build ./...
         working-directory: go-backend
 
   # ── Frontend test jobs ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Reverts the `-race` flag from #162 — the race-instrumented warm step took 78s (vs 24s) but only saved ~5s in downstream test jobs, making the critical path 50s slower
- The non-race `go build ./...` serves its purpose as a compile gate and module cache warmer

## Changes
- `.github/workflows/ci.yml`: `build-go-api` step reverted to `go build ./...`

## Test plan
- [ ] CI passes

Beads: PLAT-3u36

Generated with Claude Code