### PR TITLE
feat(frontend): add join code support to email sign-in page

### DIFF
--- a/frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx
+++ b/frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx
@@ -739,7 +739,7 @@ describe('EmailSignInPage', () => {
       expect(screen.getByLabelText(/join code/i)).toBeInTheDocument();
     });
 
-    it('strips non-alphanumeric characters from join code input', async () => {
+    it('normalizes join code input (strips dashes, uppercases)', async () => {
       const user = userEvent.setup();
       mockSignInWithEmailAndPassword.mockResolvedValue({
         user: { uid: 'test-uid', email: 'student@example.com' },

--- a/frontend/src/app/(public)/auth/signin/email/page.tsx
+++ b/frontend/src/app/(public)/auth/signin/email/page.tsx
@@ -18,6 +18,7 @@ import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import { acceptInvite, registerStudent, getStudentRegistrationInfo } from '@/lib/api/registration';
 import { ApiError } from '@/lib/api-error';
+import { normalizeJoinCode } from '@/lib/join-code';
 
 export default function EmailSignInPage() {
   return (
@@ -49,7 +50,7 @@ function EmailSignInContent() {
   const searchParams = useSearchParams();
   const inviteToken = searchParams.get('token') || searchParams.get('token');
   const urlJoinCode = searchParams.get('code') || null;
-  const joinCode = urlJoinCode || joinCodeInput.replace(/[^a-zA-Z0-9]/g, '') || null;
+  const joinCode = normalizeJoinCode(urlJoinCode || joinCodeInput) || null;
   const { isAuthenticated, setUserProfile, beginAuthFlow } = useAuth();
 
   // Redirect when authenticated (AuthContext picks up Firebase user).


### PR DESCRIPTION
## Summary
- Add join code support to the email/password sign-in page for streamlined student registration during testing
- Support both code URL parameter and manual join code input field
- Handle all error cases: INVALID_CODE, SECTION_INACTIVE, NAMESPACE_AT_CAPACITY

## Changes
- page.tsx: Added handleRegisterStudent callback, join code URL param reading, manual input field, info banner, and beginAuthFlow gating
- page.tsx: Used shared normalizeJoinCode utility for consistent code normalization
- page.test.tsx: Added comprehensive test suite for join code flow (URL param and manual input) mirroring invite token tests

## Test plan
- [x] Unit tests pass (make test-frontend)
- [x] Lint, typecheck, API import checks pass
- [ ] Manual: navigate to /auth/signin/email?code=XXXXXX, sign in, verify redirect to section
- [ ] Manual: navigate to /auth/signin/email, enter join code manually, sign in, verify redirect

Beads: PLAT-5g3g

Generated with Claude Code