### PR TITLE
fix: prevent responsive layout flash causing hidden Monaco editor

### DIFF
--- a/frontend/src/hooks/useResponsiveLayout.ts
+++ b/frontend/src/hooks/useResponsiveLayout.ts
@@ -7,7 +7,9 @@ import { useState, useEffect } from 'react';
  * Returns true for desktop layout (>= 1024px), false for mobile
  */
 export function useResponsiveLayout(breakpoint: number = 1024): boolean {
-  const [isDesktop, setIsDesktop] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(
+    () => typeof window !== 'undefined' && window.innerWidth >= breakpoint
+  );
 
   useEffect(() => {
     // Check if we're in the browser
@@ -60,12 +62,18 @@ export interface MobileViewportInfo {
  * - Desktop: >= 1024px
  */
 export function useMobileViewport(): MobileViewportInfo {
-  const [viewport, setViewport] = useState<MobileViewportInfo>({
-    isMobile: false,
-    isTablet: false,
-    isVerySmall: false,
-    isDesktop: false,
-    width: 0,
+  const [viewport, setViewport] = useState<MobileViewportInfo>(() => {
+    if (typeof window === 'undefined') {
+      return { isMobile: false, isTablet: false, isVerySmall: false, isDesktop: false, width: 0 };
+    }
+    const w = window.innerWidth;
+    return {
+      isMobile: w < 768,
+      isTablet: w >= 768 && w < 1024,
+      isVerySmall: w < 480,
+      isDesktop: w >= 1024,
+      width: w,
+    };
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Fix `useResponsiveLayout` and `useMobileViewport` hooks to use lazy `useState` initializers that read `window.innerWidth` synchronously
- Previously, both hooks initialized state as `false`/`0` and updated in `useEffect`, causing a mobile→desktop layout flash on first render
- Monaco editor initialized during the flash with a zero-height container inside `overflow-hidden` parents, leaving it permanently hidden
- This was the root cause of the staging E2E flake: `critical-paths.spec.ts:155` — Monaco element in DOM but with zero dimensions

## Root Cause

`useResponsiveLayout` had `useState(false)` → first render used mobile layout → `useEffect` set `isDesktop=true` → re-render with desktop layout. Monaco's `automaticLayout: true` (ResizeObserver) couldn't recover because the container was already clipped to zero height by nested `overflow-hidden` parents.

## Test plan

- [ ] Staging E2E `critical-paths.spec.ts` passes (Monaco editor visible immediately)
- [ ] `make test-frontend` passes
- [ ] `make typecheck-frontend` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)