### PR TITLE
fix(auth): format join code as XXX-XXX before sending to backend API

### DIFF
--- a/frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx
+++ b/frontend/src/app/(public)/auth/signin/email/__tests__/page.test.tsx
@@ -739,7 +739,7 @@ describe('EmailSignInPage', () => {
       expect(screen.getByLabelText(/join code/i)).toBeInTheDocument();
     });
 
-    it('normalizes join code input (strips dashes, uppercases)', async () => {
+    it('formats join code input as XXX-XXX for API calls', async () => {
       const user = userEvent.setup();
       mockSignInWithEmailAndPassword.mockResolvedValue({
         user: { uid: 'test-uid', email: 'student@example.com' },
@@ -752,13 +752,13 @@ describe('EmailSignInPage', () => {
 
       render(<EmailSignInPage />);
 
-      await user.type(screen.getByLabelText(/join code/i), 'TEST-CODE');
+      await user.type(screen.getByLabelText(/join code/i), 'abc123');
       await user.type(screen.getByLabelText(/email address/i), 'student@example.com');
       await user.type(screen.getByLabelText(/^password$/i), 'password123');
       await user.click(screen.getByRole('button', { name: /sign in/i }));
 
       await waitFor(() => {
-        expect(mockRegisterStudent).toHaveBeenCalledWith('TESTCODE');
+        expect(mockRegisterStudent).toHaveBeenCalledWith('ABC-123');
       });
     });
 

--- a/frontend/src/app/(public)/auth/signin/email/page.tsx
+++ b/frontend/src/app/(public)/auth/signin/email/page.tsx
@@ -18,7 +18,7 @@ import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 import { acceptInvite, registerStudent, getStudentRegistrationInfo } from '@/lib/api/registration';
 import { ApiError } from '@/lib/api-error';
-import { normalizeJoinCode } from '@/lib/join-code';
+import { formatJoinCodeForDisplay } from '@/lib/join-code';
 
 export default function EmailSignInPage() {
   return (
@@ -50,7 +50,7 @@ function EmailSignInContent() {
   const searchParams = useSearchParams();
   const inviteToken = searchParams.get('token') || searchParams.get('token');
   const urlJoinCode = searchParams.get('code') || null;
-  const joinCode = normalizeJoinCode(urlJoinCode || joinCodeInput) || null;
+  const joinCode = formatJoinCodeForDisplay(urlJoinCode || joinCodeInput) || null;
   const { isAuthenticated, setUserProfile, beginAuthFlow } = useAuth();
 
   // Redirect when authenticated (AuthContext picks up Firebase user).


### PR DESCRIPTION
## Summary
- Fix join code format mismatch: email sign-in page used `normalizeJoinCode` (strips dashes → `LCU760`) but backend's `GetSectionByJoinCode` does exact match against stored `XXX-XXX` format (`LCU-760`)
- Switch to `formatJoinCodeForDisplay` which correctly formats codes as `XXX-XXX`
- Update unit test to match new behavior

## Root Cause
Discovered via error-context.md artifact from CI run: `"Invalid join code. Please check and try again."` — the code was sent without dashes.

## Test plan
- [x] Unit tests pass (42/42 in email sign-in page)
- [ ] CI E2E tests pass (emulator mode)
- [ ] Staging E2E tests pass (this is the real validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)