### PR TITLE
perf(student): render Monaco during session join instead of blocking on it

### DIFF
--- a/frontend/src/app/(fullscreen)/student/page.tsx
+++ b/frontend/src/app/(fullscreen)/student/page.tsx
@@ -64,7 +64,7 @@ function StudentPage() {
   // Realtime session hook (only used in live mode)
   const {
     session,
-    loading: realtimeLoading,
+    loading: _realtimeLoading,
     error: realtimeError,
     isConnected,
     connectionStatus,
@@ -363,14 +363,15 @@ function StudentPage() {
     );
   }
 
-  // Loading state
-  if (mode === 'loading' || (mode === 'live' && (realtimeLoading || isJoining))) {
+  // Loading state — only gate on mode determination (needs student work + active sessions).
+  // Session state load (realtimeLoading), join (isJoining), and Centrifugo connection all
+  // happen in the background while Monaco loads its JS bundle — the student's code is
+  // already available from getStudentWork().
+  if (mode === 'loading') {
     return (
       <main className="p-8 text-center">
         <h1 className="text-2xl font-bold mb-4">Live Coding Classroom</h1>
-        <p className="text-gray-600">
-          {realtimeLoading ? 'Loading session...' : isJoining ? 'Joining session...' : 'Loading...'}
-        </p>
+        <p className="text-gray-600">Loading...</p>
         {(realtimeError || error) && (
           <div className="mt-4 max-w-md mx-auto">
             <ErrorAlert
@@ -401,22 +402,17 @@ function StudentPage() {
     );
   }
 
-  // Live mode but not yet joined
-  if (mode === 'live' && !joined) {
+  // Live mode: join failed (not in-progress, not joined, and error present)
+  if (mode === 'live' && !joined && !isJoining && error) {
     return (
       <main className="p-8 text-center">
         <h1 className="text-2xl font-bold mb-4">Live Coding Classroom</h1>
-        <p className="text-gray-600">
-          {isJoining ? 'Joining session...' : 'Loading...'}
-        </p>
-        {error && (
-          <div className="mt-4 max-w-md mx-auto">
-            <ErrorAlert
-              error={error}
-              onDismiss={() => setError(null)}
-            />
-          </div>
-        )}
+        <div className="mt-4 max-w-md mx-auto">
+          <ErrorAlert
+            error={error}
+            onDismiss={() => setError(null)}
+          />
+        </div>
       </main>
     );
   }


### PR DESCRIPTION
## Summary
- Remove `realtimeLoading` and `isJoining` from the student page render gate so Monaco starts loading its JS bundle in parallel with session join
- Previously Monaco was blocked behind 4 sequential HTTP calls; now the gate only waits for mode determination

## Context

From PLAT-t3xh. The abandoned session had also bumped E2E timeouts from 5s to 15s and proposed bundling Monaco locally. After investigation:

- **Root cause of slow Monaco**: `@monaco-editor/react` fetches ~2MB from `cdn.jsdelivr.net` at runtime. On CI this was racing with the 5s default timeout.
- **This fix**: By rendering Monaco while session join happens in background, the CDN fetch overlaps with useful work instead of waiting in a loading spinner.
- **Timeout bumps dropped**: All 16 E2E tests pass locally with default 5s timeouts after this change.
- **Local bundling deferred**: Bundling Monaco adds ~6MB to our chunks and the CDN is likely faster for real users. Not worth it unless we see CI flakes.

## Safety

The render gate change is safe because:
- Student code is already loaded from `getStudentWork()` before mode determination
- Code sync only fires when `joined === true` (line 242)
- `Connected` badge appears after join completes
- Join failure shows an error screen

## Test plan
- [x] All 16 E2E tests pass locally with default 5s timeouts
- [ ] CI E2E tests pass (the real test — CDN fetch on CI infra)

Beads: PLAT-t3xh

Generated with Claude Code