### PR TITLE
perf(executor): use JEP 330 single-file source launcher for Java

### DIFF
--- a/executor/internal/sandbox/sandbox.go
+++ b/executor/internal/sandbox/sandbox.go
@@ -211,7 +211,7 @@ func RunUnsafe(ctx context.Context, cfg Config, req Request) (*Result, error) {
 }
 
 // runUnsafeJava executes Java code directly (no nsjail) for local dev / CI.
-// It compiles with javac then runs with java.
+// Uses JEP 330 single-file source launcher to compile and run in one JVM.
 func runUnsafeJava(ctx context.Context, cfg Config, req Request) (*Result, error) {
 	tempDir, err := os.MkdirTemp("", "sandbox-java-")
 	if err != nil {
@@ -251,58 +251,12 @@ func runUnsafeJava(ctx context.Context, cfg Config, req Request) (*Result, error
 
 	start := time.Now()
 
-	// Phase 1: Compile.
-	compileTimeoutSec := timeoutSec / 2
-	if compileTimeoutSec < 5 {
-		compileTimeoutSec = 5
-	}
-	compileCtx, compileCancel := context.WithTimeout(ctx, time.Duration(compileTimeoutSec)*time.Second)
-	defer compileCancel()
-
-	javacCmd := exec.CommandContext(compileCtx, cfg.JavacPath, mainPath)
-	javacCmd.Dir = tempDir
-
-	var compilationStderr limitedBuffer
-	compilationStderr.maxBytes = maxOut
-	javacCmd.Stderr = &compilationStderr
-
-	if err := javacCmd.Run(); err != nil {
-		duration := time.Since(start)
-		exitCode := 1
-		timedOut := false
-		var pathErr *fs.PathError
-		if errors.As(err, &pathErr) && compileCtx.Err() == nil && ctx.Err() == nil {
-			// Binary not found — infrastructure failure, not a code error.
-			return nil, fmt.Errorf("javac binary not found at %s: %w", cfg.JavacPath, err)
-		}
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		}
-		if compileCtx.Err() == context.DeadlineExceeded {
-			timedOut = true
-			exitCode = -1
-		}
-		stderrStr := compilationStderr.String()
-		stderrStr = sanitizeStderrJava(stderrStr, className)
-		return &Result{
-			Stdout:     "",
-			Stderr:     stderrStr,
-			ExitCode:   exitCode,
-			TimedOut:   timedOut,
-			DurationMs: duration.Milliseconds(),
-		}, nil
-	}
-
-	// Phase 2: Execute.
-	elapsedMs := time.Since(start).Milliseconds()
-	remainingMs := int64(timeoutSec)*1000 - elapsedMs
-	if remainingMs < 1000 {
-		remainingMs = 1000
-	}
-	execCtx, execCancel := context.WithTimeout(ctx, time.Duration(remainingMs)*time.Millisecond)
+	// Single-phase: compile and run in one JVM using JEP 330 source launcher.
+	// This eliminates the second JVM startup that the old javac+java approach required.
+	execCtx, execCancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
 	defer execCancel()
 
-	javaCmd := exec.CommandContext(execCtx, cfg.JavaPath, "-cp", tempDir, className)
+	javaCmd := exec.CommandContext(execCtx, cfg.JavaPath, "-XX:TieredStopAtLevel=1", mainPath)
 	javaCmd.Dir = tempDir
 
 	if req.Stdin != "" {
@@ -628,7 +582,7 @@ func Run(ctx context.Context, cfg Config, req Request) (*Result, error) {
 }
 
 // runJava executes Java code inside an nsjail sandbox.
-// Phase 1 compiles with javac; Phase 2 runs the resulting class.
+// Uses JEP 330 single-file source launcher to compile and run in one JVM.
 func runJava(ctx context.Context, cfg Config, req Request) (*Result, error) {
 	className := extractJavaClassName(req.Code)
 	javaFile := className + ".java"
@@ -651,10 +605,7 @@ func runJava(ctx context.Context, cfg Config, req Request) (*Result, error) {
 		return nil, fmt.Errorf("nsjail binary not found at %s: %w", cfg.NsjailPath, err)
 	}
 
-	// Verify javac and java binaries exist before attempting execution.
-	if _, err := os.Stat(cfg.JavacPath); err != nil {
-		return nil, fmt.Errorf("javac binary not found at %s: %w", cfg.JavacPath, err)
-	}
+	// Verify java binary exists before attempting execution.
 	if _, err := os.Stat(cfg.JavaPath); err != nil {
 		return nil, fmt.Errorf("java binary not found at %s: %w", cfg.JavaPath, err)
 	}
@@ -665,7 +616,7 @@ func runJava(ctx context.Context, cfg Config, req Request) (*Result, error) {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(tempDir) }()
-	// Java needs write access for compilation output (.class files).
+	// Java source launcher needs write access for in-memory compilation artifacts.
 	if err := os.Chmod(tempDir, 0777); err != nil {
 		return nil, fmt.Errorf("failed to chmod temp directory: %w", err)
 	}
@@ -697,64 +648,12 @@ func runJava(ctx context.Context, cfg Config, req Request) (*Result, error) {
 
 	start := time.Now()
 
-	// Phase 1: Compile.
-	compileTimeoutSec := timeoutSec / 2
-	if compileTimeoutSec < 5 {
-		compileTimeoutSec = 5
-	}
-
-	compileCtx, compileCancel := context.WithTimeout(ctx, time.Duration(compileTimeoutSec)*time.Second+2*time.Second)
-	defer compileCancel()
-
-	compileArgs := buildJavaArgsWithTimeLimit(tempDir, compileTimeoutSec, []string{cfg.JavacPath, "/tmp/work/" + javaFile})
-
-	compileCmd := exec.CommandContext(compileCtx, cfg.NsjailPath, compileArgs...)
-
-	var compilationStderr limitedBuffer
-	compilationStderr.maxBytes = maxOut
-	compileCmd.Stdin = io.NopCloser(bytes.NewReader(nil))
-	compileCmd.Stderr = &compilationStderr
-
-	if err := compileCmd.Run(); err != nil {
-		duration := time.Since(start)
-		exitCode := 1
-		timedOut := false
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		}
-		if compileCtx.Err() == context.DeadlineExceeded {
-			timedOut = true
-			exitCode = -1
-		}
-		stderrStr := compilationStderr.String()
-		stderrStr = sanitizeStderrJava(stderrStr, className)
-		// If stderr is empty and exit code is non-zero, nsjail itself failed
-		// (--really_quiet suppresses its own error output). Return an error so the
-		// handler returns HTTP 500 instead of HTTP 200 with an empty error string.
-		if stderrStr == "" && !timedOut {
-			return nil, fmt.Errorf("nsjail compile step failed with exit code %d (no stderr — likely nsjail infrastructure failure)", exitCode)
-		}
-		return &Result{
-			Stdout:     "",
-			Stderr:     stderrStr,
-			ExitCode:   exitCode,
-			TimedOut:   timedOut,
-			DurationMs: duration.Milliseconds(),
-		}, nil
-	}
-
-	// Phase 2: Execute.
-	elapsedMs := time.Since(start).Milliseconds()
-	remainingMs := int64(timeoutSec)*1000 - elapsedMs
-	if remainingMs < 1000 {
-		remainingMs = 1000
-	}
-	remainingSec := int(math.Ceil(float64(remainingMs) / 1000.0))
-
-	execCtx, execCancel := context.WithTimeout(ctx, time.Duration(remainingSec)*time.Second+2*time.Second)
+	// Single-phase: compile and run in one JVM using JEP 330 source launcher.
+	// This eliminates the second JVM startup that the old javac+java approach required.
+	execCtx, execCancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second+2*time.Second)
 	defer execCancel()
 
-	execArgs := buildJavaArgsWithTimeLimit(tempDir, remainingSec, []string{cfg.JavaPath, "-cp", "/tmp/work", className})
+	execArgs := buildJavaArgsWithTimeLimit(tempDir, timeoutSec, []string{cfg.JavaPath, "-XX:TieredStopAtLevel=1", "/tmp/work/" + javaFile})
 
 	execCmd := exec.CommandContext(execCtx, cfg.NsjailPath, execArgs...)
 
@@ -806,7 +705,7 @@ func runJava(ctx context.Context, cfg Config, req Request) (*Result, error) {
 	// (--really_quiet suppresses its own error output). Return an error so the
 	// handler returns HTTP 500 instead of HTTP 200 with an empty error string.
 	if stderr == "" && !timedOut && exitCode != 0 {
-		return nil, fmt.Errorf("nsjail execute step failed with exit code %d (no stderr — likely nsjail infrastructure failure)", exitCode)
+		return nil, fmt.Errorf("nsjail failed with exit code %d (no stderr — likely nsjail infrastructure failure)", exitCode)
 	}
 
 	return &Result{

--- a/executor/internal/sandbox/sandbox_test.go
+++ b/executor/internal/sandbox/sandbox_test.go
@@ -779,10 +779,6 @@ func TestSanitizeStderrJava(t *testing.T) {
 
 // TestRunUnsafeJavaExecutes verifies that RunUnsafe executes a Java program.
 func TestRunUnsafeJavaExecutes(t *testing.T) {
-	javacPath, err := exec.LookPath("javac")
-	if err != nil {
-		t.Skip("javac not found")
-	}
 	javaPath, err := exec.LookPath("java")
 	if err != nil {
 		t.Skip("java not found")
@@ -790,7 +786,6 @@ func TestRunUnsafeJavaExecutes(t *testing.T) {
 
 	cfg := Config{
 		JavaPath:       javaPath,
-		JavacPath:      javacPath,
 		MaxOutputBytes: MaxOutputBytes,
 	}
 	req := Request{
@@ -813,10 +808,6 @@ func TestRunUnsafeJavaExecutes(t *testing.T) {
 
 // TestRunUnsafeJavaCompilationError verifies that compilation errors are returned in stderr.
 func TestRunUnsafeJavaCompilationError(t *testing.T) {
-	javacPath, err := exec.LookPath("javac")
-	if err != nil {
-		t.Skip("javac not found")
-	}
 	javaPath, err := exec.LookPath("java")
 	if err != nil {
 		t.Skip("java not found")
@@ -824,7 +815,6 @@ func TestRunUnsafeJavaCompilationError(t *testing.T) {
 
 	cfg := Config{
 		JavaPath:       javaPath,
-		JavacPath:      javacPath,
 		MaxOutputBytes: MaxOutputBytes,
 	}
 	req := Request{
@@ -1162,10 +1152,9 @@ func TestRunUnsafeJavaIsCommandDoesNotCompile(t *testing.T) {
 // a non-nil error (not a nil-error Result with empty stderr) when javac does not exist.
 // This is a regression test for the bug where exec.Error (binary not found) was
 // silently swallowed and returned as Result{ExitCode:1, Stderr:""}, nil.
-func TestRunUnsafeJava_MissingJavac_ReturnsError(t *testing.T) {
+func TestRunUnsafeJava_MissingJava_ReturnsError(t *testing.T) {
 	cfg := Config{
 		JavaPath:       "/nonexistent/java",
-		JavacPath:      "/nonexistent/javac",
 		MaxOutputBytes: MaxOutputBytes,
 	}
 	req := Request{
@@ -1176,14 +1165,11 @@ func TestRunUnsafeJava_MissingJavac_ReturnsError(t *testing.T) {
 
 	result, err := RunUnsafe(context.Background(), cfg, req)
 	if err == nil {
-		// If we got a nil error, the bug is present: the error was swallowed.
-		// A nil-error result with empty stderr is the silent failure we're fixing.
 		if result != nil && result.Stderr == "" && result.ExitCode != 0 {
 			t.Fatal("runUnsafeJava swallowed binary-not-found error: got nil error with empty stderr and non-zero exit code")
 		}
-		t.Fatal("expected error when javac binary does not exist, got nil")
+		t.Fatal("expected error when java binary does not exist, got nil")
 	}
-	// Error returned — this is correct behavior.
 }
 
 // TestRunUnsafeJavaCommand_MissingBinary_ReturnsError verifies that runUnsafeJavaCommand
@@ -1209,39 +1195,12 @@ func TestRunUnsafeJavaCommand_MissingBinary_ReturnsError(t *testing.T) {
 	}
 }
 
-// TestRunJava_MissingJavac_ReturnsError verifies that runJava (nsjail path) returns
-// a non-nil error when javac does not exist at the configured path.
-func TestRunJava_MissingJavac_ReturnsError(t *testing.T) {
-	cfg := Config{
-		NsjailPath:     os.Args[0], // use test binary as fake nsjail — will fail but exist
-		JavaPath:       "/nonexistent/java",
-		JavacPath:      "/nonexistent/javac",
-		MaxOutputBytes: MaxOutputBytes,
-	}
-	req := Request{
-		Code:      `public class Main { public static void main(String[] args) {} }`,
-		Language:  "java",
-		TimeoutMs: 5000,
-	}
-
-	_, err := Run(context.Background(), cfg, req)
-	if err == nil {
-		t.Fatal("expected error when javac binary does not exist at configured path, got nil")
-	}
-	if !strings.Contains(err.Error(), "javac") {
-		t.Errorf("expected error to mention javac, got: %v", err)
-	}
-}
-
 // TestRunJava_MissingJava_ReturnsError verifies that runJava (nsjail path) returns
 // a non-nil error when the java runtime does not exist at the configured path.
-// JavacPath is set to os.Args[0] (exists) so the test exercises the java binary
-// check rather than the javac check.
 func TestRunJava_MissingJava_ReturnsError(t *testing.T) {
 	cfg := Config{
 		NsjailPath:     os.Args[0],
 		JavaPath:       "/nonexistent/java",
-		JavacPath:      os.Args[0], // exists — exercise the java check, not the javac check
 		MaxOutputBytes: MaxOutputBytes,
 	}
 	req := Request{
@@ -1256,40 +1215,6 @@ func TestRunJava_MissingJava_ReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "java") {
 		t.Errorf("expected error to mention java, got: %v", err)
-	}
-}
-
-// TestRunUnsafeJava_MissingJava_Phase2_ReturnsError verifies that runUnsafeJava
-// returns a non-nil error when javac succeeds but the java binary does not exist.
-// This is a regression test for the bug where a *fs.PathError from exec.Command
-// in Phase 2 was silently swallowed as Result{ExitCode:0, Stderr:""}, nil.
-func TestRunUnsafeJava_MissingJava_Phase2_ReturnsError(t *testing.T) {
-	javacPath, err := exec.LookPath("javac")
-	if err != nil {
-		t.Skip("javac not found — cannot exercise Phase 2")
-	}
-
-	cfg := Config{
-		JavaPath:       "/nonexistent/java",
-		JavacPath:      javacPath,
-		MaxOutputBytes: MaxOutputBytes,
-	}
-	req := Request{
-		Code:      `public class Main { public static void main(String[] args) { System.out.println("hello"); } }`,
-		Language:  "java",
-		TimeoutMs: 5000,
-	}
-
-	result, err := RunUnsafe(context.Background(), cfg, req)
-	if err == nil {
-		// Bug is present: PathError was swallowed, returned as silent success.
-		if result != nil && result.Stderr == "" && result.ExitCode == 0 {
-			t.Fatal("runUnsafeJava swallowed java binary-not-found error: got nil error with empty stderr and exit code 0")
-		}
-		t.Fatalf("expected error when java binary does not exist, got nil (result=%+v)", result)
-	}
-	if !strings.Contains(err.Error(), "java binary not found") {
-		t.Errorf("expected error to mention 'java binary not found', got: %v", err)
 	}
 }
 
@@ -1313,7 +1238,6 @@ func TestRunJava_NsjailEmptyStderr_ReturnsError(t *testing.T) {
 	cfg := Config{
 		NsjailPath:     falsePath,
 		JavaPath:       os.Args[0],
-		JavacPath:      os.Args[0],
 		MaxOutputBytes: MaxOutputBytes,
 	}
 	req := Request{


### PR DESCRIPTION
## Summary
- Replace two-phase javac+java execution with single `java Main.java` (JEP 330 source launcher), eliminating one JVM startup per execution (~1-2s savings)
- Add `-XX:TieredStopAtLevel=1` to skip C2 JIT optimization on short-lived student code
- Simplify timeout logic: full timeout goes to single JVM instead of being split between compile/execute phases

## Test plan
- [x] All executor unit tests pass (`make test-executor`)
- [x] Lint clean (`make lint-executor`)
- [ ] CI pipeline (known E2E flakes unrelated to this change)
- [ ] Manual: run Java code on staging, verify compilation errors and runtime output still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)