### PR TITLE
refactor(ci): move smoke tests out of K8s pods

### DIFF
--- a/.github/workflows/deploy-pipeline.yaml
+++ b/.github/workflows/deploy-pipeline.yaml
@@ -127,7 +127,7 @@ jobs:
 
   # ── Staging deploy (gates only on image availability) ─────────────────────
   # Deploys to staging ASAP after images are pushed, before tests complete.
-  # Runs Playwright E2E tests on the CI runner via IAP SSH tunnel.
+  # Runs Playwright E2E tests against the public staging URL.
 
   deploy-staging:
     needs: [build-push-go-api, build-push-executor, build-push-frontend]
@@ -173,110 +173,6 @@ jobs:
           kubectl rollout status deployment/executor -n staging --timeout=120s
           kubectl rollout status deployment/frontend -n staging --timeout=120s
           kubectl rollout status deployment/centrifugo -n staging --timeout=120s
-      - name: Validate executor (staging)
-        run: |
-          # Run executor validation via a Kubernetes Job (Connect Gateway blocks
-          # kubectl exec/port-forward WebSocket upgrades).
-          kubectl delete job -n staging executor-validate --ignore-not-found
-
-          kubectl apply -f - <<'JOBEOF'
-          apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: executor-validate
-            namespace: staging
-            labels:
-              app: executor-validate
-          spec:
-            backoffLimit: 0
-            activeDeadlineSeconds: 120
-            ttlSecondsAfterFinished: 600
-            template:
-              metadata:
-                labels:
-                  app: executor-validate
-              spec:
-                restartPolicy: Never
-                containers:
-                  - name: validate
-                    image: curlimages/curl:latest
-                    command: ["/bin/sh", "-c"]
-                    args:
-                      - |
-                        set -e
-                        # Wait for executor to be ready (readiness probe may lag rollout status)
-                        echo "=== Waiting for executor ==="
-                        for i in $(seq 1 15); do
-                          if curl -sf --max-time 3 http://executor:8081/healthz >/dev/null 2>&1; then
-                            echo "Executor ready after $((i * 2))s"
-                            break
-                          fi
-                          if [ "$i" = "15" ]; then
-                            echo "FAIL: executor not reachable after 30s"
-                            exit 1
-                          fi
-                          sleep 2
-                        done
-
-                        echo "=== Health check ==="
-                        curl -sf http://executor:8081/healthz
-                        echo ""
-
-                        echo "=== Python execution test ==="
-                        PYTHON_RESULT=$(curl -sf -X POST http://executor:8081/execute \
-                          -H 'Content-Type: application/json' \
-                          -d '{"code":"print(\"hello\")","language":"python"}')
-                        echo "$PYTHON_RESULT"
-                        echo "$PYTHON_RESULT" | grep -q '"success":true' || { echo "FAIL: Python"; exit 1; }
-
-                        echo "=== Java execution test ==="
-                        JAVA_RESULT=$(curl -sf -X POST http://executor:8081/execute \
-                          -H 'Content-Type: application/json' \
-                          -d '{"code":"public class Main { public static void main(String[] args) { System.out.println(\"hello from java\"); } }","language":"java"}')
-                        echo "$JAVA_RESULT"
-                        echo "$JAVA_RESULT" | grep -q '"success":true' || { echo "FAIL: Java"; exit 1; }
-
-                        echo "=== All executor tests passed ==="
-                    resources:
-                      requests:
-                        cpu: 100m
-                        memory: 64Mi
-                      limits:
-                        cpu: 200m
-                        memory: 128Mi
-          JOBEOF
-
-          # Poll for job completion via .status.succeeded / .status.failed.
-          echo "Waiting for executor-validate job to complete..."
-          DEADLINE=$((SECONDS + 180))
-          RESULT=""
-          while [ $SECONDS -lt $DEADLINE ]; do
-            SUCCEEDED=$(kubectl get job executor-validate -n staging \
-              -o jsonpath='{.status.succeeded}' 2>/dev/null || echo "")
-            FAILED=$(kubectl get job executor-validate -n staging \
-              -o jsonpath='{.status.failed}' 2>/dev/null || echo "")
-            if [ "$SUCCEEDED" = "1" ]; then
-              RESULT="passed"
-              break
-            elif [ "$FAILED" = "1" ]; then
-              RESULT="failed"
-              break
-            fi
-            sleep 5
-          done
-
-          if [ "$RESULT" = "passed" ]; then
-            echo "Executor validation logs:"
-            kubectl logs job/executor-validate -n staging
-          elif [ "$RESULT" = "failed" ]; then
-            echo "::error::Executor validation failed"
-            kubectl logs job/executor-validate -n staging 2>/dev/null || true
-            exit 1
-          else
-            echo "::error::Executor validation timed out"
-            kubectl logs job/executor-validate -n staging 2>/dev/null || true
-            exit 1
-          fi
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -320,6 +216,21 @@ jobs:
       - name: Wait for staging-ingress-proxy rollout
         run: |
           kubectl rollout status deployment/staging-ingress-proxy --timeout=120s
+      - name: Validate executor sandbox (staging)
+        run: |
+          # Access executor directly via port-forward (not exposed publicly).
+          kubectl port-forward -n staging svc/executor 8081:8081 &
+          PF_PID=$!
+          trap 'kill $PF_PID 2>/dev/null || true' EXIT
+          for i in $(seq 1 15); do
+            curl -sf --max-time 2 http://localhost:8081/healthz >/dev/null 2>&1 && break
+            if [ "$i" = "15" ]; then
+              echo "::error::Port-forward to executor not ready after 30s"
+              exit 1
+            fi
+            sleep 2
+          done
+          ./scripts/validate-executor-sandbox.sh
       - name: Run staging E2E tests
         env:
           BASE_URL: https://staging.eval.delquillan.com
@@ -417,11 +328,20 @@ jobs:
           done
           echo "::error::Ingress not ready after 300s"
           exit 1
+      - name: Read smoke test credentials
+        run: |
+          FIREBASE_API_KEY=$(kubectl get configmap frontend-config -o jsonpath='{.data.NEXT_PUBLIC_FIREBASE_API_KEY}')
+          SMOKE_TEST_PASSWORD=$(kubectl get secret smoke-test-secrets -o jsonpath='{.data.SMOKE_TEST_PASSWORD}' | base64 -d)
+          echo "FIREBASE_API_KEY=$FIREBASE_API_KEY" >> "$GITHUB_ENV"
+          echo "::add-mask::$SMOKE_TEST_PASSWORD"
+          echo "SMOKE_TEST_PASSWORD=$SMOKE_TEST_PASSWORD" >> "$GITHUB_ENV"
       - name: Smoke test
         run: ./scripts/smoke-test.sh
         env:
           SMOKE_TEST_URL: https://eval.delquillan.com
           GCP_PROJECT_ID: eval-prod-485520
+          FIREBASE_API_KEY: ${{ env.FIREBASE_API_KEY }}
+          SMOKE_TEST_PASSWORD: ${{ env.SMOKE_TEST_PASSWORD }}
 
   notify-failure:
     needs: deploy-prod

--- a/Makefile
+++ b/Makefile
@@ -182,10 +182,19 @@ validate-deploy-pipeline:
 # ──────────────────────────────────────────────
 # Smoke tests (post-deploy)
 # ──────────────────────────────────────────────
-.PHONY: smoke-test
+.PHONY: smoke-test validate-executor-sandbox test-smoke-test test-validate-executor-sandbox
 
 smoke-test:
 	./scripts/smoke-test.sh
+
+validate-executor-sandbox:
+	./scripts/validate-executor-sandbox.sh
+
+test-smoke-test:
+	./scripts/test-smoke-test.sh
+
+test-validate-executor-sandbox:
+	./scripts/test-validate-executor-sandbox.sh
 
 # ──────────────────────────────────────────────
 # Local development

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 # Post-deploy smoke tests for production.
 # Verifies all services are responding through the ingress, frontend config
-# is properly injected, executor sandbox is working, and authentication
-# works end-to-end.
+# is properly injected, and authentication works end-to-end.
 #
 # Usage:
 #   ./scripts/smoke-test.sh [BASE_URL]
@@ -13,9 +12,9 @@ set -euo pipefail
 #   SMOKE_TEST_URL      (default: https://eval.delquillan.com)
 #   SMOKE_TEST_TIMEOUT  (default: 90)  — max seconds to wait per check
 #   SMOKE_TEST_INTERVAL (default: 5)   — seconds between retries
-#   GCP_PROJECT_ID      — required for auth test (skipped if absent)
-#
-# Requires: kubectl configured with cluster access (Connect Gateway or direct).
+#   FIREBASE_API_KEY    — required for auth test
+#   SMOKE_TEST_PASSWORD — required for auth test
+#   GCP_PROJECT_ID      — required for smoke-test user creation (if user doesn't exist)
 
 BASE_URL="${1:-${SMOKE_TEST_URL:-https://eval.delquillan.com}}"
 TIMEOUT="${SMOKE_TEST_TIMEOUT:-90}"
@@ -24,7 +23,6 @@ MAX_ATTEMPTS=$(( TIMEOUT / INTERVAL ))
 
 TOTAL=0
 FAILURES=()
-SKIPPED=()
 
 # --- Helpers ---
 
@@ -70,15 +68,6 @@ run_check() {
     echo "  FAIL: ${description}"
     FAILURES+=("$description")
   fi
-}
-
-skip_check() {
-  local description="$1"
-  local reason="$2"
-  TOTAL=$(( TOTAL + 1 ))
-  SKIPPED+=("$description")
-  echo "Checking ${description} ..."
-  echo "  SKIP: ${reason}"
 }
 
 # --- Check functions ---
@@ -147,147 +136,6 @@ check_no_placeholders() {
   return 0
 }
 
-# --- Executor sandbox tests ---
-# Validates the nsjail sandbox is correctly configured in production.
-# These checks can ONLY run in production — CI skips them because nsjail
-# requires privileged mode + proper kernel capabilities.
-#
-# Runs a single ephemeral pod that executes all tests against the executor
-# service from inside the cluster, then reads results via kubectl logs.
-# Connect Gateway does not support the WebSocket upgrade that kubectl
-# exec/port-forward require, so we cannot use those.
-
-# Clean up any smoke-test pods on exit (covers interrupts, failures, etc.).
-cleanup_smoke_pods() {
-  kubectl delete pods -l smoke-test=executor --ignore-not-found >/dev/null 2>&1 || true
-}
-trap cleanup_smoke_pods EXIT
-
-# Python script that runs all executor sandbox tests from inside the cluster.
-# Outputs one JSON line per test: {"name": "...", "pass": bool, "detail": "..."}.
-read -r -d '' EXECUTOR_TEST_SCRIPT << 'PYEOF' || true
-import urllib.request, json, sys
-
-EXECUTOR_URL = "http://executor:8081"
-
-# Wait for the executor service to become reachable.  After a deploy with
-# strategy=Recreate, the Service endpoints may lag behind the rollout status.
-import time
-for _attempt in range(30):
-    try:
-        urllib.request.urlopen(f"{EXECUTOR_URL}/healthz", timeout=5)
-        break
-    except Exception:
-        time.sleep(2)
-
-def execute(code, timeout_ms=10000):
-    req = urllib.request.Request(f"{EXECUTOR_URL}/execute",
-        data=json.dumps({"code": code, "timeout_ms": timeout_ms}).encode(),
-        headers={"Content-Type": "application/json"})
-    with urllib.request.urlopen(req, timeout=30) as r:
-        return json.loads(r.read().decode())
-
-def result(name, ok, detail=""):
-    print(json.dumps({"name": name, "pass": ok, "detail": detail}), flush=True)
-
-# 1. Basic execution
-try:
-    r = execute('print("sandbox-ok")')
-    ok = r.get("success") and "sandbox-ok" in r.get("output", "")
-    result("Basic execution", ok, f"success={r.get('success')} output={r.get('output','')!r}")
-except Exception as e:
-    result("Basic execution", False, str(e))
-
-# 2. Timeout enforcement
-try:
-    r = execute("import time; time.sleep(60)", timeout_ms=1000)
-    ok = r.get("success") is False
-    result("Timeout enforcement", ok, f"success={r.get('success')}")
-except Exception as e:
-    result("Timeout enforcement", False, str(e))
-
-# 3. Network isolation
-try:
-    r = execute('import socket; s=socket.socket(); s.connect(("8.8.8.8",53)); print("CONNECTED")')
-    ok = not (r.get("success") and "CONNECTED" in r.get("output", ""))
-    result("Network isolation", ok, f"success={r.get('success')} output={r.get('output','')!r}")
-except Exception as e:
-    result("Network isolation", False, str(e))
-
-# 4. Filesystem isolation
-try:
-    r = execute('print(open("/etc/passwd").read())')
-    ok = r.get("success") is False
-    result("Filesystem isolation", ok, f"success={r.get('success')}")
-except Exception as e:
-    result("Filesystem isolation", False, str(e))
-
-# 5. Memory limit
-try:
-    r = execute('x = "A" * (512 * 1024 * 1024); print("allocated")')
-    ok = not (r.get("success") and "allocated" in r.get("output", ""))
-    result("Memory limit", ok, f"success={r.get('success')} error={r.get('error','')[:80]}")
-except Exception as e:
-    result("Memory limit", False, str(e))
-PYEOF
-
-check_executor_sandbox() {
-  local pod_name="smoke-exec-$$-${RANDOM}"
-
-  # activeDeadlineSeconds: self-destruct after 120s even if nothing cleans up.
-  # The go-api label lets traffic through the executor NetworkPolicy.
-  kubectl run "$pod_name" \
-    --image=python:3.12-slim \
-    --restart=Never \
-    --labels=app=go-api,smoke-test=executor \
-    --override-type=merge \
-    --overrides='{"spec":{"activeDeadlineSeconds":120,"tolerations":[{"operator":"Exists"}]}}' \
-    -- python3 -c "$EXECUTOR_TEST_SCRIPT" >/dev/null 2>&1 || {
-    echo "  ERROR: failed to create smoke-test pod" >&2
-    return 1
-  }
-
-  # Wait for the pod to finish.
-  local phase=""
-  for i in $(seq 1 60); do
-    phase=$(kubectl get pod "$pod_name" -o jsonpath='{.status.phase}' 2>/dev/null)
-    if [[ "$phase" == "Succeeded" || "$phase" == "Failed" ]]; then
-      break
-    fi
-    sleep 2
-  done
-
-  local logs
-  logs=$(kubectl logs "$pod_name" 2>/dev/null)
-  kubectl delete pod "$pod_name" --ignore-not-found >/dev/null 2>&1
-
-  if [[ -z "$logs" ]]; then
-    echo "  ERROR: no output from smoke-test pod (phase=${phase})" >&2
-    return 1
-  fi
-
-  # Parse JSON lines from the pod output.
-  local failed=0 idx=0 total
-  total=$(echo "$logs" | wc -l)
-  while IFS= read -r line; do
-    idx=$(( idx + 1 ))
-    local name pass detail
-    name=$(echo "$line" | jq -r '.name')
-    pass=$(echo "$line" | jq -r '.pass')
-    detail=$(echo "$line" | jq -r '.detail')
-
-    echo "  [${idx}/${total}] ${name}..."
-    if [[ "$pass" == "true" ]]; then
-      echo "    OK"
-    else
-      echo "    FAILED: ${detail}"
-      failed=1
-    fi
-  done <<< "$logs"
-
-  return "$failed"
-}
-
 # --- Auth round-trip test ---
 # Validates the full authentication pipeline: Firebase API key → Identity
 # Platform sign-in → JWT → Go API middleware.
@@ -295,21 +143,29 @@ check_executor_sandbox() {
 # Uses a persistent smoke-test user (created on first run, reused forever).
 # The deploy SA only needs firebaseauth.users.create — no delete, no get,
 # no list. Password is stored in a k8s Secret managed by Terraform.
+#
+# Credentials are passed as environment variables:
+#   FIREBASE_API_KEY     — Firebase API key (from frontend-config ConfigMap)
+#   SMOKE_TEST_PASSWORD  — smoke-test user password (from smoke-test-secrets Secret)
 
 SMOKE_TEST_EMAIL="smoke-test@eval-internal.test"
 IDP_API="https://identitytoolkit.googleapis.com/v1"
 
 check_auth_roundtrip() {
-  # 1. Read credentials from the cluster
+  # 1. Read credentials from environment variables
   local api_key password
-  api_key=$(kubectl get configmap frontend-config -o jsonpath='{.data.NEXT_PUBLIC_FIREBASE_API_KEY}' 2>/dev/null) || {
-    echo "  ERROR: Could not read Firebase API key from frontend-config ConfigMap"
+
+  if [[ -z "${FIREBASE_API_KEY:-}" ]]; then
+    echo "  ERROR: FIREBASE_API_KEY env var is required but not set"
     return 1
-  }
-  password=$(kubectl get secret smoke-test-secrets -o jsonpath='{.data.SMOKE_TEST_PASSWORD}' 2>/dev/null | base64 -d) || {
-    echo "  ERROR: Could not read SMOKE_TEST_PASSWORD from smoke-test-secrets Secret"
+  fi
+  api_key="${FIREBASE_API_KEY}"
+
+  if [[ -z "${SMOKE_TEST_PASSWORD:-}" ]]; then
+    echo "  ERROR: SMOKE_TEST_PASSWORD env var is required but not set"
     return 1
-  }
+  fi
+  password="${SMOKE_TEST_PASSWORD}"
 
   # 2. Try to sign in (works if user already exists from a previous deploy)
   local signin_body signin_response signin_code
@@ -378,43 +234,30 @@ check_auth_roundtrip() {
   return 0
 }
 
-# --- Run checks ---
+# --- Run checks (only when executed directly, not sourced) ---
 
-echo "Smoke testing ${BASE_URL} (timeout ${TIMEOUT}s per check)"
-echo ""
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Smoke testing ${BASE_URL} (timeout ${TIMEOUT}s per check)"
+  echo ""
 
-retry_check "Frontend" "${BASE_URL}/" check_frontend
-run_check   "Frontend config (no placeholders)" check_no_placeholders
-retry_check "Go API" "${BASE_URL}/api/v1/auth/me" check_api
-retry_check "Centrifugo" "${BASE_URL}/connection/websocket" check_centrifugo
+  retry_check "Frontend" "${BASE_URL}/" check_frontend
+  run_check   "Frontend config (no placeholders)" check_no_placeholders
+  retry_check "Go API" "${BASE_URL}/api/v1/auth/me" check_api
+  retry_check "Centrifugo" "${BASE_URL}/connection/websocket" check_centrifugo
+  run_check   "Auth round-trip" check_auth_roundtrip
 
-# Executor sandbox and auth tests require kubectl
-if command -v kubectl &>/dev/null; then
-  run_check "Executor sandbox" check_executor_sandbox
+  echo ""
+  echo "=============================="
+  PASSED=$(( TOTAL - ${#FAILURES[@]} ))
+  echo "Smoke tests: ${PASSED} passed, ${#FAILURES[@]} failed (${TOTAL} total)"
 
-  if [[ -n "${GCP_PROJECT_ID:-}" ]] && command -v gcloud &>/dev/null; then
-    run_check "Auth round-trip" check_auth_roundtrip
-  else
-    skip_check "Auth round-trip" "requires GCP_PROJECT_ID and gcloud"
+  if [ ${#FAILURES[@]} -gt 0 ]; then
+    echo "Failures:"
+    for f in "${FAILURES[@]}"; do
+      echo "  - $f"
+    done
+    exit 1
   fi
-else
-  skip_check "Executor sandbox" "requires kubectl"
-  skip_check "Auth round-trip" "requires kubectl, GCP_PROJECT_ID, and gcloud"
+
+  echo "All smoke tests passed."
 fi
-
-# --- Summary ---
-
-echo ""
-echo "=============================="
-PASSED=$(( TOTAL - ${#FAILURES[@]} - ${#SKIPPED[@]} ))
-echo "Smoke tests: ${PASSED} passed, ${#FAILURES[@]} failed, ${#SKIPPED[@]} skipped (${TOTAL} total)"
-
-if [ ${#FAILURES[@]} -gt 0 ]; then
-  echo "Failures:"
-  for f in "${FAILURES[@]}"; do
-    echo "  - $f"
-  done
-  exit 1
-fi
-
-echo "All smoke tests passed."

--- a/scripts/test-smoke-test.sh
+++ b/scripts/test-smoke-test.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# Tests for smoke-test.sh structure and auth-roundtrip behavior.
+# Run from repo root: bash scripts/test-smoke-test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE_SCRIPT="$SCRIPT_DIR/smoke-test.sh"
+
+PASS=0
+FAIL=0
+
+# ── Test helpers ────────────────────────────────────────────────────────────
+
+assert_exit() {
+  local desc="$1"
+  local expected_exit="$2"
+  shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_output_contains() {
+  local desc="$1"
+  local pattern="$2"
+  shift 2
+  local output
+  output=$("$@" 2>&1 || true)
+  if echo "$output" | grep -qE "$pattern"; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (output did not contain '$pattern')"
+    echo "  Output was: $output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1"
+  local pattern="$2"
+  if ! grep -qE "$pattern" "$SMOKE_SCRIPT" 2>/dev/null; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (smoke-test.sh still contains '$pattern')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1"
+  local pattern="$2"
+  if grep -qE "$pattern" "$SMOKE_SCRIPT" 2>/dev/null; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (smoke-test.sh does not contain '$pattern')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMPDIR_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR_ROOT"
+}
+trap cleanup EXIT
+
+SYSTEM_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: executor sandbox code removed
+# ────────────────────────────────────────────────────────────────────────────
+
+assert_not_contains \
+  "check_executor_sandbox function is removed" \
+  "check_executor_sandbox"
+
+assert_not_contains \
+  "EXECUTOR_TEST_SCRIPT variable is removed" \
+  "EXECUTOR_TEST_SCRIPT"
+
+assert_not_contains \
+  "cleanup_smoke_pods trap is removed" \
+  "cleanup_smoke_pods"
+
+assert_not_contains \
+  "kubectl run pod invocation is removed" \
+  "kubectl run"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: kubectl-gated conditional is removed
+# ────────────────────────────────────────────────────────────────────────────
+
+assert_not_contains \
+  "kubectl-gated conditional is removed" \
+  "command -v kubectl"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: check_auth_roundtrip reads from env vars not kubectl
+# ────────────────────────────────────────────────────────────────────────────
+
+assert_contains \
+  "check_auth_roundtrip reads FIREBASE_API_KEY env var" \
+  "FIREBASE_API_KEY"
+
+assert_contains \
+  "check_auth_roundtrip reads SMOKE_TEST_PASSWORD env var" \
+  "SMOKE_TEST_PASSWORD"
+
+assert_not_contains \
+  "check_auth_roundtrip no longer uses kubectl to read api_key" \
+  'kubectl get configmap frontend-config'
+
+assert_not_contains \
+  "check_auth_roundtrip no longer uses kubectl to read password" \
+  'kubectl get secret smoke-test-secrets'
+
+# ────────────────────────────────────────────────────────────────────────────
+# Behavior: missing FIREBASE_API_KEY exits 1 with clear error
+# We need to run only the check_auth_roundtrip function in isolation.
+# We source smoke-test.sh with mocked curl and only call check_auth_roundtrip.
+# ────────────────────────────────────────────────────────────────────────────
+
+MOCK_DIR="$(mktemp -d -p "$TMPDIR_ROOT")"
+
+# Mock curl to never be called (we expect failure before curl)
+cat > "$MOCK_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "curl-called-unexpectedly" >&2
+exit 1
+EOF
+chmod +x "$MOCK_DIR/curl"
+
+# Source smoke-test.sh to get check_auth_roundtrip, then call it directly.
+# We run it in a subshell with no FIREBASE_API_KEY set.
+missing_api_key_exit=0
+missing_api_key_output=$(
+  env -i \
+    PATH="${MOCK_DIR}:${SYSTEM_PATH}" \
+    HOME="${HOME:-/root}" \
+    SMOKE_TEST_PASSWORD=somepassword \
+    bash -c "
+      source '$SMOKE_SCRIPT' 2>/dev/null || true
+      check_auth_roundtrip
+    " 2>&1
+) || missing_api_key_exit=$?
+
+if [ "$missing_api_key_exit" -ne 0 ]; then
+  echo "PASS: Missing FIREBASE_API_KEY causes check_auth_roundtrip to fail"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: Missing FIREBASE_API_KEY did not cause check_auth_roundtrip to fail (exit 0)"
+  echo "  Output was: $missing_api_key_output"
+  FAIL=$((FAIL + 1))
+fi
+
+if echo "$missing_api_key_output" | grep -qiE "FIREBASE_API_KEY|api.key|missing|required"; then
+  echo "PASS: Missing FIREBASE_API_KEY prints helpful error mentioning FIREBASE_API_KEY"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: Missing FIREBASE_API_KEY error message does not mention FIREBASE_API_KEY"
+  echo "  Output was: $missing_api_key_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Behavior: missing SMOKE_TEST_PASSWORD exits 1 with clear error
+# ────────────────────────────────────────────────────────────────────────────
+
+missing_password_exit=0
+missing_password_output=$(
+  env -i \
+    PATH="${MOCK_DIR}:${SYSTEM_PATH}" \
+    HOME="${HOME:-/root}" \
+    FIREBASE_API_KEY=some-api-key \
+    bash -c "
+      source '$SMOKE_SCRIPT' 2>/dev/null || true
+      check_auth_roundtrip
+    " 2>&1
+) || missing_password_exit=$?
+
+if [ "$missing_password_exit" -ne 0 ]; then
+  echo "PASS: Missing SMOKE_TEST_PASSWORD causes check_auth_roundtrip to fail"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: Missing SMOKE_TEST_PASSWORD did not cause check_auth_roundtrip to fail (exit 0)"
+  echo "  Output was: $missing_password_output"
+  FAIL=$((FAIL + 1))
+fi
+
+if echo "$missing_password_output" | grep -qiE "SMOKE_TEST_PASSWORD|password|missing|required"; then
+  echo "PASS: Missing SMOKE_TEST_PASSWORD prints helpful error mentioning SMOKE_TEST_PASSWORD"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: Missing SMOKE_TEST_PASSWORD error message does not mention SMOKE_TEST_PASSWORD"
+  echo "  Output was: $missing_password_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Behavior: with both env vars set, check_auth_roundtrip calls IDP API
+# ────────────────────────────────────────────────────────────────────────────
+
+MOCK_DIR2="$(mktemp -d -p "$TMPDIR_ROOT")"
+
+# Real jq for JSON parsing
+REAL_JQ="$(command -v jq)"
+
+cat > "$MOCK_DIR2/jq" <<EOF
+#!/usr/bin/env bash
+exec "${REAL_JQ}" "\$@"
+EOF
+chmod +x "$MOCK_DIR2/jq"
+
+cat > "$MOCK_DIR2/gcloud" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"auth print-access-token"* ]]; then
+  echo "mock-token"
+fi
+EOF
+chmod +x "$MOCK_DIR2/gcloud"
+
+# Mock curl: signInWithPassword returns 200 with idToken
+cat > "$MOCK_DIR2/curl" <<'EOF'
+#!/usr/bin/env bash
+args=("$@")
+output_file=""
+for i in "${!args[@]}"; do
+  if [[ "${args[$i]}" == "-o" ]]; then
+    output_file="${args[$((i+1))]}"
+    break
+  fi
+done
+url=""
+for arg in "${args[@]}"; do
+  if [[ "$arg" == http* ]]; then url="$arg"; break; fi
+done
+
+if [[ "$url" == *"signInWithPassword"* ]]; then
+  [[ -n "$output_file" ]] && printf '{"idToken":"fake-id-token","localId":"uid-123"}' > "$output_file"
+  printf '200'
+elif [[ "$url" == *"/api/v1/auth/me"* ]]; then
+  printf '404'
+else
+  printf '200'
+fi
+EOF
+chmod +x "$MOCK_DIR2/curl"
+
+with_creds_exit=0
+with_creds_output=$(
+  env -i \
+    PATH="${MOCK_DIR2}:${SYSTEM_PATH}" \
+    HOME="${HOME:-/root}" \
+    FIREBASE_API_KEY=test-api-key \
+    SMOKE_TEST_PASSWORD=test-password \
+    SMOKE_TEST_URL=https://eval.delquillan.com \
+    GCP_PROJECT_ID=test-project \
+    BASE_URL=https://eval.delquillan.com \
+    bash -c "
+      source '$SMOKE_SCRIPT' 2>/dev/null || true
+      check_auth_roundtrip
+    " 2>&1
+) || with_creds_exit=$?
+
+if [ "$with_creds_exit" -eq 0 ]; then
+  echo "PASS: check_auth_roundtrip succeeds with FIREBASE_API_KEY + SMOKE_TEST_PASSWORD set"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: check_auth_roundtrip failed even with both env vars set (exit $with_creds_exit)"
+  echo "  Output was: $with_creds_output"
+  FAIL=$((FAIL + 1))
+fi
+
+if echo "$with_creds_output" | grep -qiE "Auth round-trip OK|round.trip"; then
+  echo "PASS: check_auth_roundtrip outputs success message"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: check_auth_roundtrip did not output success message"
+  echo "  Output was: $with_creds_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: auth round-trip is always run (not gated on kubectl or GCP_PROJECT_ID)
+# ────────────────────────────────────────────────────────────────────────────
+
+assert_not_contains \
+  "auth round-trip not gated on GCP_PROJECT_ID conditional" \
+  'GCP_PROJECT_ID.*gcloud.*check_auth_roundtrip'
+
+assert_not_contains \
+  "auth skip message for kubectl is removed" \
+  'skip_check.*Auth round-trip.*kubectl'
+
+# ────────────────────────────────────────────────────────────────────────────
+# Results
+# ────────────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/test-validate-executor-sandbox.sh
+++ b/scripts/test-validate-executor-sandbox.sh
@@ -1,0 +1,474 @@
+#!/usr/bin/env bash
+# Tests for validate-executor-sandbox.sh structure and behavior.
+# Run from repo root: bash scripts/test-validate-executor-sandbox.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXECUTOR_SCRIPT="$SCRIPT_DIR/validate-executor-sandbox.sh"
+
+PASS=0
+FAIL=0
+
+# ── Test helpers ────────────────────────────────────────────────────────────
+
+assert_exit() {
+  local desc="$1"
+  local expected_exit="$2"
+  shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_output_contains() {
+  local desc="$1"
+  local pattern="$2"
+  shift 2
+  local output
+  output=$("$@" 2>&1 || true)
+  if echo "$output" | grep -qE "$pattern"; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (output did not contain '$pattern')"
+    echo "  Output was: $output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1"
+  local pattern="$2"
+  if ! grep -qE "$pattern" "$EXECUTOR_SCRIPT" 2>/dev/null; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (validate-executor-sandbox.sh still contains '$pattern')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1"
+  local pattern="$2"
+  if grep -qE "$pattern" "$EXECUTOR_SCRIPT" 2>/dev/null; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (validate-executor-sandbox.sh does not contain '$pattern')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+file_exists() {
+  local desc="$1"
+  local file="$2"
+  if [ -f "$file" ]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (file does not exist: $file)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMPDIR_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR_ROOT"
+}
+trap cleanup EXIT
+
+SYSTEM_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: script exists
+# ────────────────────────────────────────────────────────────────────────────
+
+file_exists \
+  "validate-executor-sandbox.sh exists" \
+  "$EXECUTOR_SCRIPT"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: no K8s dependencies
+# ────────────────────────────────────────────────────────────────────────────
+
+# Check that kubectl is not used in executable lines (comments are fine)
+if ! grep -v '^[[:space:]]*#' "$EXECUTOR_SCRIPT" | grep -qE 'kubectl' 2>/dev/null; then
+  echo "PASS: does not use kubectl (in executable code)"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: does not use kubectl (in executable code)"
+  FAIL=$((FAIL + 1))
+fi
+
+assert_not_contains \
+  "does not reference K8s Jobs" \
+  "kind: Job"
+
+assert_not_contains \
+  "does not reference executor:8081 directly (uses BASE_URL)" \
+  "http://executor:8081"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: uses parameterized BASE_URL
+# ────────────────────────────────────────────────────────────────────────────
+
+assert_contains \
+  "accepts BASE_URL parameter or env var" \
+  "BASE_URL"
+
+assert_contains \
+  "defaults BASE_URL to http://localhost:8081" \
+  "localhost:8081"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: includes required test cases
+# ────────────────────────────────────────────────────────────────────────────
+
+assert_contains \
+  "includes basic Python execution test" \
+  "Basic.*[Pp]ython|[Pp]ython.*[Bb]asic"
+
+assert_contains \
+  "includes basic Java execution test" \
+  "Basic.*[Jj]ava|[Jj]ava.*[Bb]asic"
+
+assert_contains \
+  "includes timeout enforcement test" \
+  "[Tt]imeout"
+
+assert_contains \
+  "includes network isolation test" \
+  "[Nn]etwork"
+
+assert_contains \
+  "includes filesystem isolation test" \
+  "[Ff]ilesystem"
+
+assert_contains \
+  "includes memory limit test" \
+  "[Mm]emory"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Structure: hits the /execute endpoint (not /execute on executor:8081)
+# ────────────────────────name: ────────────────────────────────────────────────
+
+assert_contains \
+  "sends requests to /execute endpoint" \
+  "/execute"
+
+assert_contains \
+  "sends requests to /healthz endpoint" \
+  "/healthz"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Behavior: missing BASE_URL still uses default (https://localhost:8081)
+# The script should not require BASE_URL — it has a sensible default
+# ────────────────────────────────────────────────────────────────────────────
+
+MOCK_DIR_DEFAULT="$(mktemp -d -p "$TMPDIR_ROOT")"
+
+# Mock curl: healthz returns 200, execute fails immediately
+cat > "$MOCK_DIR_DEFAULT/curl" <<'EOF'
+#!/usr/bin/env bash
+# Capture args to detect which endpoint is being called
+for arg in "$@"; do
+  if [[ "$arg" == *"localhost:8081"* ]]; then
+    # Confirm default URL is used
+    printf '{"success":false,"error":"mock-fail"}' > /tmp/mock-body-default 2>/dev/null || true
+    printf '200'
+    exit 0
+  fi
+done
+printf '000'
+exit 0
+EOF
+chmod +x "$MOCK_DIR_DEFAULT/curl"
+
+# Run the script without BASE_URL — expect it to try localhost:8081
+default_url_output=$(
+  env -i \
+    PATH="${MOCK_DIR_DEFAULT}:${SYSTEM_PATH}" \
+    HOME="${HOME:-/root}" \
+    bash "$EXECUTOR_SCRIPT" 2>&1
+) || true
+
+if echo "$default_url_output" | grep -qE "localhost:8081|localhost"; then
+  echo "PASS: script uses localhost:8081 as default BASE_URL"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: script did not use localhost:8081 as default BASE_URL"
+  echo "  Output was: $default_url_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Behavior: executor unreachable causes health check failure
+# ────────────────────────────────────────────────────────────────────────────
+
+MOCK_DIR_DOWN="$(mktemp -d -p "$TMPDIR_ROOT")"
+
+cat > "$MOCK_DIR_DOWN/curl" <<'EOF'
+#!/usr/bin/env bash
+# Simulate executor being down
+output_file=""
+for i in "${!@}"; do
+  if [[ "${@:$((i+1)):1}" == "-o" ]]; then
+    output_file="${@:$((i+2)):1}"
+    break
+  fi
+done
+for i in "${!args[@]}"; do
+  if [[ "${args[$i]}" == "-o" ]]; then
+    output_file="${args[$((i+1))]}"
+    break
+  fi
+done
+# Simple: find -o arg
+args=("$@")
+for ((idx=0; idx<${#args[@]}; idx++)); do
+  if [[ "${args[$idx]}" == "-o" ]]; then
+    output_file="${args[$((idx+1))]}"
+    break
+  fi
+done
+[[ -n "$output_file" ]] && printf '' > "$output_file"
+printf '000'
+EOF
+chmod +x "$MOCK_DIR_DOWN/curl"
+
+down_exit=0
+down_output=$(
+  env -i \
+    PATH="${MOCK_DIR_DOWN}:${SYSTEM_PATH}" \
+    HOME="${HOME:-/root}" \
+    BASE_URL=https://localhost:8081 \
+    bash "$EXECUTOR_SCRIPT" 2>&1
+) || down_exit=$?
+
+if [ "$down_exit" -ne 0 ]; then
+  echo "PASS: executor unreachable causes script to exit non-zero"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: executor unreachable did not cause script to exit non-zero"
+  echo "  Output was: $down_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Behavior: all tests pass with a mocked executor that returns success
+# ────────────────────────────────────────────────────────────────────────────
+
+MOCK_DIR_SUCCESS="$(mktemp -d -p "$TMPDIR_ROOT")"
+
+# Real jq for JSON parsing
+REAL_JQ="$(command -v jq)"
+cat > "$MOCK_DIR_SUCCESS/jq" <<EOF
+#!/usr/bin/env bash
+exec "${REAL_JQ}" "\$@"
+EOF
+chmod +x "$MOCK_DIR_SUCCESS/jq"
+
+# Mock curl: healthz returns 200, all execute calls return success
+cat > "$MOCK_DIR_SUCCESS/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+args=("$@")
+output_file=""
+for ((idx=0; idx<${#args[@]}; idx++)); do
+  if [[ "${args[$idx]}" == "-o" ]]; then
+    output_file="${args[$((idx+1))]}"
+    break
+  fi
+done
+
+url=""
+for arg in "${args[@]}"; do
+  if [[ "$arg" == http* ]]; then url="$arg"; break; fi
+done
+
+if [[ "$url" == *"/healthz"* ]]; then
+  [[ -n "$output_file" ]] && printf '%s' 'ok' > "$output_file"
+  printf '%s' '200'
+elif [[ "$url" == *"/execute"* ]]; then
+  # Check if this is a timeout test (timeout_ms <= 1000) or isolation test
+  data_arg=""
+  for ((idx=0; idx<${#args[@]}; idx++)); do
+    if [[ "${args[$idx]}" == "-d" || "${args[$idx]}" == "--data" ]]; then
+      data_arg="${args[$((idx+1))]}"
+      break
+    fi
+  done
+
+  # Detect if this is a "should fail" test based on the code content.
+  # Pattern: detect isolation/timeout test code embedded in JSON.
+  # Note: do NOT use timeout_ms value — 10000 would match "1000" as substring.
+  if echo "$data_arg" | grep -qE 'time\.sleep|8\.8\.8\.8|/etc/passwd|512 \* 1024 \* 1024'; then
+    # These should "fail" — sandbox correctly rejects the dangerous/timeout code
+    [[ -n "$output_file" ]] && printf '%s' '{"success":false,"error":"killed","output":""}' > "$output_file"
+  elif echo "$data_arg" | grep -q '"language":"java"'; then
+    # Java execution — return java-specific output
+    [[ -n "$output_file" ]] && printf '%s' '{"success":true,"output":"java-sandbox-ok\\n","error":""}' > "$output_file"
+  else
+    # Normal Python execution — succeed and return output (use \\n for JSON-safe newline)
+    [[ -n "$output_file" ]] && printf '%s' '{"success":true,"output":"sandbox-ok\\n","error":""}' > "$output_file"
+  fi
+  printf '%s' '200'
+else
+  [[ -n "$output_file" ]] && printf '%s' '' > "$output_file"
+  printf '%s' '000'
+fi
+CURLEOF
+chmod +x "$MOCK_DIR_SUCCESS/curl"
+
+success_exit=0
+success_output=$(
+  env -i \
+    PATH="${MOCK_DIR_SUCCESS}:${SYSTEM_PATH}" \
+    HOME="${HOME:-/root}" \
+    BASE_URL=https://localhost:8081 \
+    bash "$EXECUTOR_SCRIPT" 2>&1
+) || success_exit=$?
+
+if [ "$success_exit" -eq 0 ]; then
+  echo "PASS: all tests pass when executor returns correct responses"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: script exited non-zero even though executor returned correct responses"
+  echo "  Exit: $success_exit"
+  echo "  Output was: $success_output"
+  FAIL=$((FAIL + 1))
+fi
+
+if echo "$success_output" | grep -qiE "passed|PASS|All.*passed"; then
+  echo "PASS: success output contains 'passed' summary"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: success output does not contain 'passed' summary"
+  echo "  Output was: $success_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Behavior: a test failure causes non-zero exit
+# ────────────────────────────────────────────────────────────────────────────
+
+MOCK_DIR_FAIL="$(mktemp -d -p "$TMPDIR_ROOT")"
+
+cat > "$MOCK_DIR_FAIL/jq" <<EOF
+#!/usr/bin/env bash
+exec "${REAL_JQ}" "\$@"
+EOF
+chmod +x "$MOCK_DIR_FAIL/jq"
+
+# Mock curl: healthz ok, all execute calls return "success":true even for
+# dangerous code (simulating a broken sandbox where isolation is not enforced)
+cat > "$MOCK_DIR_FAIL/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+args=("$@")
+output_file=""
+for ((idx=0; idx<${#args[@]}; idx++)); do
+  if [[ "${args[$idx]}" == "-o" ]]; then
+    output_file="${args[$((idx+1))]}"
+    break
+  fi
+done
+
+url=""
+for arg in "${args[@]}"; do
+  if [[ "$arg" == http* ]]; then url="$arg"; break; fi
+done
+
+if [[ "$url" == *"/healthz"* ]]; then
+  [[ -n "$output_file" ]] && printf '%s' 'ok' > "$output_file"
+  printf '%s' '200'
+elif [[ "$url" == *"/execute"* ]]; then
+  # Broken sandbox: always succeed, even for dangerous code.
+  # This simulates missing isolation — all security tests should FAIL.
+  # Return language-appropriate output so basic tests pass, but security
+  # tests detect the sandbox is broken (they return success when they should fail).
+  if echo "$@" | grep -q '"language":"java"'; then
+    [[ -n "$output_file" ]] && printf '%s' '{"success":true,"output":"java-sandbox-ok\\n","error":""}' > "$output_file"
+  elif echo "$@" | grep -q '8\.8\.8\.8'; then
+    # Network: sandbox should block but broken sandbox "succeeds" with CONNECTED
+    [[ -n "$output_file" ]] && printf '%s' '{"success":true,"output":"CONNECTED\\n","error":""}' > "$output_file"
+  else
+    [[ -n "$output_file" ]] && printf '%s' '{"success":true,"output":"sandbox-ok\\n","error":""}' > "$output_file"
+  fi
+  printf '%s' '200'
+else
+  [[ -n "$output_file" ]] && printf '%s' '' > "$output_file"
+  printf '%s' '000'
+fi
+CURLEOF
+chmod +x "$MOCK_DIR_FAIL/curl"
+
+fail_exit=0
+fail_output=$(
+  env -i \
+    PATH="${MOCK_DIR_FAIL}:${SYSTEM_PATH}" \
+    HOME="${HOME:-/root}" \
+    BASE_URL=https://localhost:8081 \
+    bash "$EXECUTOR_SCRIPT" 2>&1
+) || fail_exit=$?
+
+if [ "$fail_exit" -ne 0 ]; then
+  echo "PASS: broken sandbox causes script to exit non-zero"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: broken sandbox did not cause script to exit non-zero"
+  echo "  Output was: $fail_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Behavior: BASE_URL can be passed as positional argument
+# ────────────────────────────────────────────────────────────────────────────
+
+MOCK_DIR_ARG="$(mktemp -d -p "$TMPDIR_ROOT")"
+
+cat > "$MOCK_DIR_ARG/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+# Check that the URL contains the custom base
+for arg in "$@"; do
+  if [[ "$arg" == *"custom-host:9999"* ]]; then
+    printf '200'
+    exit 0
+  fi
+done
+printf '000'
+CURLEOF
+chmod +x "$MOCK_DIR_ARG/curl"
+
+arg_output=$(
+  env -i \
+    PATH="${MOCK_DIR_ARG}:${SYSTEM_PATH}" \
+    HOME="${HOME:-/root}" \
+    bash "$EXECUTOR_SCRIPT" "http://custom-host:9999" 2>&1
+) || true
+
+if echo "$arg_output" | grep -qE "custom-host:9999|custom.host"; then
+  echo "PASS: BASE_URL positional argument is used"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: BASE_URL positional argument was not used"
+  echo "  Output was: $arg_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Results
+# ────────────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/validate-deploy-pipeline.py
+++ b/scripts/validate-deploy-pipeline.py
@@ -7,6 +7,7 @@ Checks that:
 - build-push-executor uses content-hash caching to skip unnecessary builds
 - The skip path produces a commit-SHA tag (so deploy-staging works unchanged)
 - The build path also produces commit-SHA and latest tags
+- deploy-staging runs executor sandbox validation via kubectl port-forward (not a K8s Job)
 
 Exit code 0 = valid, 1 = invalid.
 """
@@ -46,13 +47,17 @@ def validate(workflow_path):
         "build-push-go-api",
         "build-push-executor",
         "build-push-frontend",
-        "build-push-test-runner",
         "ci",
         "deploy-staging",
         "deploy-prod",
     ]
     for job in required_jobs:
         ok &= check(job in jobs, f"job exists: {job}")
+
+    ok &= check(
+        "build-push-test-runner" not in jobs,
+        "job removed: build-push-test-runner (replaced by public staging approach)",
+    )
 
     # ── build-push-executor: content-hash caching ─────────────────────────────
     executor_job = jobs.get("build-push-executor", {})
@@ -109,6 +114,25 @@ def validate(workflow_path):
         "deploy-staging needs: build-push-executor",
     )
 
+    # ── deploy-staging: executor sandbox validation via kubectl port-forward ────
+    # The K8s Job approach is replaced with a script that runs on the CI runner
+    # via kubectl port-forward to the executor service (not exposed publicly).
+    staging_steps = staging_job.get("steps", [])
+    staging_steps_str = str(staging_steps)
+
+    ok &= check(
+        "validate-executor-sandbox.sh" in staging_steps_str,
+        "deploy-staging: runs validate-executor-sandbox.sh script",
+    )
+    ok &= check(
+        "executor-validate" not in staging_steps_str,
+        "deploy-staging: no longer uses K8s executor-validate Job",
+    )
+    ok &= check(
+        "port-forward" in staging_steps_str,
+        "deploy-staging: uses kubectl port-forward to reach executor",
+    )
+
     # ── deploy-prod: gates on deploy-staging + ci ─────────────────────────────
     prod_job = jobs.get("deploy-prod", {})
     prod_needs = prod_job.get("needs", [])
@@ -116,6 +140,27 @@ def validate(workflow_path):
         prod_needs = [prod_needs]
     ok &= check("deploy-staging" in prod_needs, "deploy-prod needs: deploy-staging")
     ok &= check("ci" in prod_needs, "deploy-prod needs: ci")
+
+    # ── deploy-prod: smoke test credentials read from cluster before smoke test ─
+    prod_steps = prod_job.get("steps", [])
+    prod_steps_str = str(prod_steps)
+
+    ok &= check(
+        "FIREBASE_API_KEY" in prod_steps_str,
+        "deploy-prod: reads FIREBASE_API_KEY for smoke test",
+    )
+    ok &= check(
+        "SMOKE_TEST_PASSWORD" in prod_steps_str,
+        "deploy-prod: reads SMOKE_TEST_PASSWORD for smoke test",
+    )
+    ok &= check(
+        "frontend-config" in prod_steps_str,
+        "deploy-prod: reads FIREBASE_API_KEY from frontend-config ConfigMap",
+    )
+    ok &= check(
+        "smoke-test-secrets" in prod_steps_str,
+        "deploy-prod: reads SMOKE_TEST_PASSWORD from smoke-test-secrets Secret",
+    )
 
     return ok
 

--- a/scripts/validate-executor-sandbox.sh
+++ b/scripts/validate-executor-sandbox.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Executor sandbox validation for staging CI pipeline.
+# Validates that the nsjail sandbox is correctly configured: execution works,
+# timeouts are enforced, network/filesystem access is blocked, and memory
+# limits hold.
+#
+# Usage:
+#   ./scripts/validate-executor-sandbox.sh [BASE_URL]
+#
+# Environment:
+#   BASE_URL  (default: http://localhost:8081)  — executor URL (via kubectl port-forward)
+#
+# The executor is reached directly (not through a proxy):
+#   BASE_URL/execute   — code execution endpoint
+#   BASE_URL/healthz   — executor health check
+#
+# In CI, the executor is accessed via kubectl port-forward to avoid
+# exposing it publicly through the staging ingress.
+#
+# Tests included:
+#   - Basic Python execution
+#   - Basic Java execution
+#   - Timeout enforcement
+#   - Network isolation
+#   - Filesystem isolation
+#   - Memory limits
+
+BASE_URL="${1:-${BASE_URL:-http://localhost:8081}}"
+EXECUTE_URL="${BASE_URL}/execute"
+HEALTH_URL="${BASE_URL}/healthz"
+
+TIMEOUT_CURL=30   # seconds for each curl call
+TOTAL=0
+FAILURES=()
+
+# --- Helpers ---
+
+result() {
+  local name="$1"
+  local ok="$2"       # "true" or "false"
+  local detail="${3:-}"
+
+  TOTAL=$(( TOTAL + 1 ))
+  if [[ "$ok" == "true" ]]; then
+    echo "  [${TOTAL}] ${name}: OK"
+  else
+    echo "  [${TOTAL}] ${name}: FAILED${detail:+ — ${detail}}"
+    FAILURES+=("$name")
+  fi
+}
+
+execute() {
+  local code="$1"
+  local language="${2:-python}"
+  local timeout_ms="${3:-10000}"
+
+  local body_file
+  body_file=$(mktemp)
+  trap "rm -f '$body_file'" RETURN
+
+  local http_code
+  http_code=$(curl -s -o "$body_file" -w '%{http_code}' \
+    --max-time "${TIMEOUT_CURL}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "{\"code\":$(printf '%s' "$code" | jq -Rs .),\"language\":\"${language}\",\"timeout_ms\":${timeout_ms}}" \
+    "${EXECUTE_URL}" 2>/dev/null || echo "000")
+
+  if [[ "$http_code" != "200" ]]; then
+    echo "{\"success\":false,\"output\":\"\",\"error\":\"http_${http_code}\"}"
+    rm -f "$body_file"
+    return 0
+  fi
+
+  cat "$body_file"
+  rm -f "$body_file"
+}
+
+get_field() {
+  local json="$1"
+  local field="$2"
+  # Use tostring to correctly handle false (jq // empty treats false as empty)
+  echo "$json" | jq -r ".${field} | tostring" 2>/dev/null || echo ""
+}
+
+# --- Health check ---
+
+echo "Executor sandbox validation against ${BASE_URL}"
+echo ""
+echo "Health check..."
+
+health_code=$(curl -s -o /dev/null -w '%{http_code}' \
+  --max-time "${TIMEOUT_CURL}" \
+  "${HEALTH_URL}" 2>/dev/null || echo "000")
+
+if [[ "$health_code" != "200" ]]; then
+  echo "FATAL: Executor health check failed (HTTP ${health_code}) at ${HEALTH_URL}"
+  echo "  Is the staging ingress proxy deployed and the executor running?"
+  exit 1
+fi
+
+echo "  Health check OK (HTTP 200)"
+echo ""
+echo "Running sandbox tests..."
+echo ""
+
+# --- Test 1: Basic Python execution ---
+
+r=$(execute 'print("sandbox-ok")' python 10000)
+ok=$(get_field "$r" success)
+output=$(get_field "$r" output)
+if [[ "$ok" == "true" && "$output" == *"sandbox-ok"* ]]; then
+  result "Basic Python execution" true
+else
+  result "Basic Python execution" false "success=${ok} output=${output@Q}"
+fi
+
+# --- Test 2: Basic Java execution ---
+
+JAVA_CODE='public class Main { public static void main(String[] args) { System.out.println("java-sandbox-ok"); } }'
+r=$(execute "$JAVA_CODE" java 30000)
+ok=$(get_field "$r" success)
+output=$(get_field "$r" output)
+if [[ "$ok" == "true" && "$output" == *"java-sandbox-ok"* ]]; then
+  result "Basic Java execution" true
+else
+  result "Basic Java execution" false "success=${ok} output=${output@Q}"
+fi
+
+# --- Test 3: Timeout enforcement ---
+
+r=$(execute 'import time; time.sleep(60)' python 1000)
+ok=$(get_field "$r" success)
+if [[ "$ok" == "false" ]]; then
+  result "Timeout enforcement" true
+else
+  result "Timeout enforcement" false "expected success=false but got success=${ok}"
+fi
+
+# --- Test 4: Network isolation ---
+
+r=$(execute 'import socket; s=socket.socket(); s.connect(("8.8.8.8",53)); print("CONNECTED")' python 10000)
+ok=$(get_field "$r" success)
+output=$(get_field "$r" output)
+# Sandbox should either fail the connection or not output CONNECTED
+network_blocked="false"
+if [[ "$ok" == "false" ]]; then
+  network_blocked="true"
+elif [[ "$output" != *"CONNECTED"* ]]; then
+  network_blocked="true"
+fi
+if [[ "$network_blocked" == "true" ]]; then
+  result "Network isolation" true
+else
+  result "Network isolation" false "sandbox allowed outbound connection: success=${ok} output=${output@Q}"
+fi
+
+# --- Test 5: Filesystem isolation ---
+
+r=$(execute 'print(open("/etc/passwd").read())' python 10000)
+ok=$(get_field "$r" success)
+if [[ "$ok" == "false" ]]; then
+  result "Filesystem isolation" true
+else
+  result "Filesystem isolation" false "expected success=false but sandbox allowed /etc/passwd read"
+fi
+
+# --- Test 6: Memory limits ---
+
+r=$(execute 'x = "A" * (512 * 1024 * 1024); print("allocated")' python 10000)
+ok=$(get_field "$r" success)
+output=$(get_field "$r" output)
+mem_limited="false"
+if [[ "$ok" == "false" ]]; then
+  mem_limited="true"
+elif [[ "$output" != *"allocated"* ]]; then
+  mem_limited="true"
+fi
+if [[ "$mem_limited" == "true" ]]; then
+  result "Memory limits" true
+else
+  result "Memory limits" false "sandbox allowed 512MB allocation: success=${ok} output=${output@Q}"
+fi
+
+# --- Summary ---
+
+echo ""
+echo "=============================="
+PASSED=$(( TOTAL - ${#FAILURES[@]} ))
+echo "Executor sandbox validation: ${PASSED} passed, ${#FAILURES[@]} failed (${TOTAL} total)"
+
+if [ ${#FAILURES[@]} -gt 0 ]; then
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+echo "All executor sandbox checks passed."


### PR DESCRIPTION
## Summary
- Replaces K8s Job executor validation with `kubectl port-forward` + standalone script
- Extracts executor sandbox tests into `validate-executor-sandbox.sh` (6 tests: Python, Java, timeout, network, filesystem, memory)
- Cleans prod `smoke-test.sh`: removes all kubectl/pod-based testing, auth reads from env vars
- Adds pipeline validator checks for port-forward approach

Cherry-pick of #181 (which was accidentally merged into `feature/public-staging-ingress` instead of `main`).

## Test plan
- [x] `scripts/test-validate-executor-sandbox.sh` — 20/20 pass
- [x] `scripts/test-smoke-test.sh` — 17/17 pass
- [x] `scripts/validate-deploy-pipeline.py` — 24/24 pass
- [ ] Staging deploy: executor sandbox tests pass via port-forward
- [ ] Prod deploy: smoke tests pass with env-var-based auth

Beads: PLAT-blot, PLAT-blot.1, PLAT-blot.2, PLAT-blot.3

Generated with [Claude Code](https://claude.com/claude-code)