### PR TITLE
chore(ci): rename job keys for scanability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
         default: false
       cross-boundary-only:
-        description: 'Run only cross-boundary tests (contract, e2e, go-api-integration)'
+        description: 'Run only cross-boundary tests (system-contract, system-playwright, go-api-integration)'
         type: boolean
         default: false
 
@@ -292,7 +292,7 @@ jobs:
 
   # ── Cross-stack jobs ────────────────────────────────────────────────────────
 
-  contract-tests:
+  system-contract:
     needs: changes
     if: |
       needs.changes.outputs.go-backend == 'true' ||
@@ -471,7 +471,7 @@ jobs:
           docker stop executor 2>/dev/null || true
           docker rm executor 2>/dev/null || true
 
-  e2e-tests:
+  system-playwright:
     needs: changes
     if: |
       needs.changes.outputs.go-backend == 'true' ||

--- a/.github/workflows/deploy-pipeline.yaml
+++ b/.github/workflows/deploy-pipeline.yaml
@@ -121,7 +121,7 @@ jobs:
           docker push $REGISTRY/frontend:${{ github.sha }}
 
   # ── CI workflow (cross-boundary tests only) ───────────────────────────────
-  # Runs contract tests, E2E tests, and go-api integration (no lint/unit tests
+  # Runs system-contract, system-playwright, and go-api-integration (no lint/unit tests
   # — those already passed on the PR). deploy-prod gates on this passing, but
   # deploy-staging does NOT wait for it.
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,7 +17,7 @@ env:
   TF_VERSION: '1.14'
 
 jobs:
-  validate:
+  check-terraform:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Rename `contract-tests` → `system-contract` and `e2e-tests` → `system-playwright` in CI to distinguish full-stack tests from single-component integration tests
- Rename `validate` → `check-terraform` in terraform workflow for consistency

## Changes
- `.github/workflows/ci.yml`: Rename 2 job keys + update input description
- `.github/workflows/terraform.yaml`: Rename 1 job key
- `.github/workflows/deploy-pipeline.yaml`: Update comment referencing old names

## Test plan
- [ ] CI runs successfully with renamed jobs (no cross-file `needs:` references to update)

Beads: PLAT-jovw

Generated with Claude Code