### PR TITLE
fix(auth): add COOP header to unblock federated sign-in popups

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,6 +4,22 @@ const nextConfig = {
   reactStrictMode: true,
   // Empty turbopack config to silence the error - we use webpack config below
   turbopack: {},
+  // Allow Firebase signInWithPopup to communicate back to the opener window.
+  // Without this, COOP isolation blocks the popup from closing and returning
+  // the auth result, breaking federated sign-in (Google, GitHub, Microsoft).
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Cross-Origin-Opener-Policy',
+            value: 'same-origin-allow-popups',
+          },
+        ],
+      },
+    ];
+  },
   // Proxy /api/* to the Go backend when API_PROXY_URL is set.
   // In dev/test: avoids CORS by routing through Next.js.
   // In production: not needed (Ingress/Gateway handles routing).


### PR DESCRIPTION
## Summary

- Adds `Cross-Origin-Opener-Policy: same-origin-allow-popups` header to all frontend routes
- Fixes federated sign-in (Google, GitHub, Microsoft) which broke when browser COOP enforcement tightened
- Without this header, `signInWithPopup` popups are isolated in separate browsing contexts and cannot communicate auth results back to the opener window

Closes PLAT-0een

## Test plan

- [ ] Verify Google sign-in popup opens, completes auth, and closes successfully
- [ ] Verify GitHub and Microsoft sign-in work the same way
- [ ] Verify response headers include `Cross-Origin-Opener-Policy: same-origin-allow-popups`
- [ ] Verify no COOP-related console errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)