### PR TITLE
feat(ci): add push-button PR-to-staging deployment

### DIFF
--- a/.github/workflows/deploy-pr-staging.yaml
+++ b/.github/workflows/deploy-pr-staging.yaml
@@ -33,17 +33,22 @@ jobs:
         id: get-sha
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr }}
         run: |
-          SHA=$(gh pr view ${{ inputs.pr }} \
-            --repo ${{ github.repository }} \
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid PR number: $PR_NUMBER"
+            exit 1
+          fi
+          SHA=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
             --json headRefOid \
             --jq '.headRefOid')
           if [ -z "$SHA" ]; then
-            echo "::error::Could not resolve HEAD SHA for PR ${{ inputs.pr }}"
+            echo "::error::Could not resolve HEAD SHA for PR $PR_NUMBER"
             exit 1
           fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "Resolved PR ${{ inputs.pr }} to SHA: $SHA"
+          echo "Resolved PR $PR_NUMBER to SHA: $SHA"
 
   # ── Parallel build-push jobs ──────────────────────────────────────────────
   # Build and push all three images tagged with the PR branch HEAD SHA.
@@ -207,8 +212,8 @@ jobs:
   # and a link to this run. Always runs (success or failure).
 
   comment-on-pr:
-    needs: [resolve-ref, deploy-staging]
-    if: always()
+    needs: [resolve-ref, build-push-go-api, build-push-executor, build-push-frontend, deploy-staging]
+    if: always() && needs.resolve-ref.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -217,12 +222,13 @@ jobs:
         env:
           SHA: ${{ needs.resolve-ref.outputs.sha }}
           DEPLOY_RESULT: ${{ needs.deploy-staging.result }}
+          PR_NUMBER: ${{ inputs.pr }}
         with:
           script: |
             const sha = process.env.SHA;
             const deployResult = process.env.DEPLOY_RESULT;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const prNumber = parseInt('${{ inputs.pr }}', 10);
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
 
             let body;
             if (deployResult === 'success') {


### PR DESCRIPTION
## Summary
- Adds a new `workflow_dispatch` workflow that deploys any PR branch to the staging environment on demand
- Resolves the PR's HEAD SHA, builds all 3 images in parallel, deploys via kustomize, and comments on the PR with the result

## Changes
- New `.github/workflows/deploy-pr-staging.yaml` with:
  - `resolve-ref` job: validates PR number and gets branch HEAD SHA via `gh pr view`
  - 3 parallel `build-push-*` jobs mirroring deploy-pipeline.yaml patterns (including executor content-hash caching)
  - `deploy-staging` job: kustomize overlay + kubectl apply (same as main pipeline)
  - `comment-on-pr` job: posts staging URL + commit SHA on success, or failure details
- Concurrency group `deploy-pr-staging` with `cancel-in-progress: true` (one PR deploy at a time)
- No E2E tests — deploy-only for manual testing
- Input validation and shell quoting to prevent injection

## Usage
```bash
gh workflow run deploy-pr-staging -f pr=42
```

## Test plan
- [ ] Trigger workflow with a valid PR number — images build, staging deploys, PR comment posted
- [ ] Trigger with invalid PR number — workflow fails gracefully with error message
- [ ] Cancel one run while another is in progress — first is cancelled (concurrency group)

Beads: PLAT-3grc

Generated with Claude Code