### PR TITLE
Lift worktree mechanics into hooks; block tool calls in stale worktrees

### DIFF
--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,20 +1,23 @@
 # Work Coordinator
 
-Coordinate work on **$ARGUMENTS** using the coordinator workflow.
+User request: $ARGUMENTS
 
-## 1. Parse Input
+**All work happens in a worktree under `.claude/worktrees/`.** The directory you're in may be irrelevant — re-evaluate from the request above.
 
-- **`bd-*`** (beads ID): `bd show $ARGUMENTS --json`. If epic: `bd list --parent $ARGUMENTS --json`
-- **`#<number>`** (GitHub issue): Fetch and convert to beads issue:
-  ```bash
-  gh issue view <number> --json title,body,labels,number
-  bd create "<title>" -d "GitHub: #<number> — <description>" -t <type> -p <priority> --json
-  ```
-  Map GitHub labels to beads types. Priority 1 for bugs, 2 for features/tasks.
-- **Other** (ad-hoc description): The coordinator will create a beads issue.
+Run `git worktree list`, then:
 
-## 2. Follow the coordinator skill instructions below
+1. Extending an in-flight change → enter its existing worktree.
+2. Stacking new work on an in-flight branch → new worktree from that branch.
+3. Otherwise → new worktree from `origin/main`.
 
----
+To create one (from the main repo root):
+
+```bash
+git fetch origin <base> --quiet
+git worktree add .claude/worktrees/<slug> -b feature/<slug> origin/<base>
+ln -s "$PWD/frontend/node_modules" .claude/worktrees/<slug>/frontend/node_modules
+```
+
+Then `EnterWorktree(path: .claude/worktrees/<slug>)`. If already in a worktree, `ExitWorktree(action: "keep")` first.
 
 @.claude/skills/coordinator/SKILL.md

--- a/.claude/hooks/ask-on-main-edit.sh
+++ b/.claude/hooks/ask-on-main-edit.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Hook: Require user approval for Edit/Write/NotebookEdit targeting files in
+# the main checkout. Worktrees under .claude/worktrees/ are silently allowed.
+#
+# Checks the file_path argument rather than cwd — an agent can be inside a
+# worktree but use an absolute path that points into the main repo, and that
+# is the most common failure mode.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+
+# No file_path — nothing to gate.
+[ -z "$FILE_PATH" ] && echo '{}' && exit 0
+
+ABS_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+
+MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||' || true)
+[ -z "$MAIN_REPO" ] && echo '{}' && exit 0
+
+# Outside the repo entirely — allow.
+case "$ABS_PATH" in
+  "$MAIN_REPO"/*) ;;
+  *) echo '{}'; exit 0 ;;
+esac
+
+# Inside a worktree — allow.
+case "$ABS_PATH" in
+  "$MAIN_REPO"/.claude/worktrees/*) echo '{}'; exit 0 ;;
+esac
+
+# Edit targets the main checkout — ask the user.
+REASON="This edit targets the main checkout ($ABS_PATH). Any change going into the repo should be made on a feature branch in a worktree (see .claude/commands/work.md). Approve only if this is a local-testing edit that will not be committed."
+
+jq -n --arg reason "$REASON" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "ask",
+    permissionDecisionReason: $reason
+  }
+}'

--- a/.claude/hooks/block-stale-worktree.sh
+++ b/.claude/hooks/block-stale-worktree.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# PreToolUse (matcher: *): block tool calls while the agent is in a worktree
+# it hasn't acknowledged yet. The marker is written by mark-stale-worktree.sh
+# at SessionStart. EnterWorktree and ExitWorktree clear the marker on the
+# way through so the agent has an exit even when everything else is blocked.
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+GIT_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[ -z "$GIT_TOP" ] && { echo '{}'; exit 0; }
+
+MARKER="$GIT_TOP/.claude/.stale-worktree"
+
+# Escape hatches: either tool clears the marker so the next call passes through.
+if [ "$TOOL_NAME" = "ExitWorktree" ] || [ "$TOOL_NAME" = "EnterWorktree" ]; then
+  rm -f "$MARKER" 2>/dev/null || true
+  echo '{}'
+  exit 0
+fi
+
+# No marker — pass through.
+[ ! -e "$MARKER" ] && { echo '{}'; exit 0; }
+
+# Marker present, tool isn't an escape — block.
+REASON=$(cat <<EOF
+BLOCKED: this session started inside a worktree ($GIT_TOP) and has not acknowledged it. Continuing risks stale reads and wrong-branch edits.
+
+Before doing anything else, choose one:
+  - ExitWorktree(action: "keep") — leave the worktree, continue from the main checkout
+  - EnterWorktree(path: <other-worktree>) — switch to the worktree that matches the user's request
+
+If this is NOT a fresh session and another agent is legitimately working in this worktree, pause and check in with the user before proceeding.
+EOF
+)
+
+jq -n --arg reason "$REASON" '{decision: "block", reason: $reason}'

--- a/.claude/hooks/mark-stale-worktree.sh
+++ b/.claude/hooks/mark-stale-worktree.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SessionStart: if pwd is inside a worktree, drop a marker so the
+# block-stale-worktree PreToolUse hook can block tool calls until the agent
+# acknowledges the worktree via ExitWorktree or EnterWorktree.
+#
+# The marker lives in the worktree's working tree (.claude/.stale-worktree)
+# and is excluded by .gitignore so it doesn't leak into commits or new
+# worktree checkouts.
+
+set -euo pipefail
+
+GIT_COMMON=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||' || true)
+GIT_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+
+[ -z "$GIT_COMMON" ] && exit 0
+[ -z "$GIT_TOP" ] && exit 0
+
+# In a worktree iff working-tree root differs from the main repo root.
+if [ "$GIT_TOP" != "$GIT_COMMON" ]; then
+  mkdir -p "$GIT_TOP/.claude" 2>/dev/null || true
+  touch "$GIT_TOP/.claude/.stale-worktree" 2>/dev/null || true
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -28,27 +28,16 @@ if [ -n "$git_common" ] && [ -n "$git_dir" ] && [ "$git_common" != "$git_dir" ];
   in_worktree=true
 fi
 
-if [ "$in_worktree" = true ]; then
+# In-worktree case is handled deterministically by mark-stale-worktree.sh +
+# block-stale-worktree.sh. Only the stale-branch-in-main-checkout case needs a
+# text warning here.
+if [ "$in_worktree" = false ] && [ -n "$current_branch" ] && [ "$current_branch" != "main" ]; then
   cat <<EOF
-# WARNING: session started in a worktree
+CRITICAL FIRST INSTRUCTION: You are on branch '$current_branch' from a previous session.
 
-You are in a worktree, likely left over from a previous session.
-  Current directory: $current_dir
-  Branch: $current_branch
-  Main repository: $main_repo
-
-**Unless the user explicitly asks you to work in this worktree**, return to main first:
-  cd $main_repo && git checkout main
-
-EOF
-elif [ -n "$current_branch" ] && [ "$current_branch" != "main" ]; then
-  cat <<EOF
-# WARNING: session started on branch '$current_branch'
-
-You are on a non-main branch, likely left over from a previous session.
-
-**Unless the user explicitly asks you to work on this branch**, return to main first:
-  git checkout main
+Before doing ANYTHING else, run: git checkout main
+Continuing on a stale branch will lead to wrong diffs and lost work.
+Do NOT respond to the user's message until you have returned to main (unless the user explicitly asks you to work on this branch).
 
 EOF
 fi

--- a/.claude/hooks/set-repo-root.sh
+++ b/.claude/hooks/set-repo-root.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Hook: SessionStart + CwdChanged — keep REPO_ROOT pointing to the current repo/worktree root.
+# Other hooks can then resolve their scripts via "$REPO_ROOT/.claude/hooks/..."
+# regardless of which worktree or subdirectory the agent is currently in.
+
+set -euo pipefail
+
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+  if [ -n "$REPO_ROOT" ]; then
+    echo "export REPO_ROOT=$REPO_ROOT" >> "$CLAUDE_ENV_FILE"
+  fi
+fi

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Hook: WorktreeCreate — set up a worktree branched from the caller's HEAD.
+# Fires when an agent spawns a subagent with isolation: "worktree".
+# Stdout is consumed as the worktree path.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Resolve the main repo root (follows symlinks through worktrees)
+MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+[ -z "$MAIN_REPO" ] && MAIN_REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+
+NAME=$(echo "$INPUT" | jq -r '.name // empty')
+[ -z "$NAME" ] && { echo ""; exit 0; }
+
+WORKTREE_PATH="$MAIN_REPO/.claude/worktrees/$NAME"
+
+# Branch from the caller's HEAD so subagent worktrees inherit the
+# coordinator's feature branch.
+BASE_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+
+if [ ! -d "$WORKTREE_PATH" ]; then
+  git -C "$MAIN_REPO" worktree add "$WORKTREE_PATH" -b "worktree-$NAME" "$BASE_BRANCH" >/dev/null 2>&1 || true
+fi
+
+# Symlink frontend deps so the worktree doesn't reinstall on every spawn.
+[ ! -e "$WORKTREE_PATH/frontend/node_modules" ] && ln -s "$MAIN_REPO/frontend/node_modules" "$WORKTREE_PATH/frontend/node_modules" 2>/dev/null || true
+
+echo "$WORKTREE_PATH"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,22 +14,68 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash .claude/hooks/set-repo-root.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/mark-stale-worktree.sh"
+          },
+          {
+            "type": "command",
             "command": "bash .claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$REPO_ROOT/.claude/hooks/set-repo-root.sh\""
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$REPO_ROOT/.claude/hooks/worktree-create.sh\""
           }
         ]
       }
     ],
     "PreToolUse": [
       {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$REPO_ROOT/.claude/hooks/block-stale-worktree.sh\""
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/block-branch-switch.sh"
+            "command": "bash \"$REPO_ROOT/.claude/hooks/block-branch-switch.sh\""
           },
           {
             "type": "command",
-            "command": "bash .claude/hooks/block-hook-bypass.sh"
+            "command": "bash \"$REPO_ROOT/.claude/hooks/block-hook-bypass.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$REPO_ROOT/.claude/hooks/ask-on-main-edit.sh\""
           }
         ]
       }

--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -15,9 +15,9 @@ You are the single entry point for all implementation work. You triage incoming 
 
 ### 1. Parse Input
 
-The input is either a beads ID or an ad-hoc description.
+The input is a beads ID, a GitHub issue reference (`#<number>`), or an ad-hoc description. When the input could plausibly be a beads ID, try `bd show <input> --json` first; if it returns an issue, treat it as one. Otherwise fall through.
 
-**If beads ID:**
+**Beads ID:**
 ```bash
 bd show <id> --json
 ```
@@ -27,8 +27,15 @@ If it's an epic, also fetch subtasks:
 bd list --parent <id> --json
 ```
 
-**If ad-hoc description (no beads ID):**
-Create a beads issue first:
+**GitHub issue (`#<number>`):** Fetch and convert to a beads issue:
+```bash
+gh issue view <number> --json title,body,labels,number
+bd create "<title>" -d "GitHub: #<number> — <description>" -t <type> -p <priority> --json
+```
+
+Map GitHub labels to beads types. Priority 1 for bugs, 2 for features/tasks.
+
+**Ad-hoc description:** Create a beads issue:
 ```bash
 bd create "<description>" -t <task|bug|feature> -p 2 --json
 ```
@@ -41,32 +48,9 @@ If the issue is a fix for code on an existing feature branch (e.g., CI failure o
 
 ## Branch Mode
 
-All work uses branches and PRs. Uses worktree isolation for subagents.
+You're in your worktree from `/work` — `pwd` is its path. Implementer subagents spawn with `isolation: "worktree"` (the `WorktreeCreate` hook handles branch + frontend/node_modules symlink). Rebase, reviewer, and test-runner subagents enter your existing worktree via a `WORKTREE` field — do NOT use `isolation: "worktree"` for those.
 
-### 1. Setup
-
-Create the feature branch from main:
-
-```bash
-git fetch origin main
-git branch feature/<work-name> origin/main
-```
-
-Then enter a worktree for the coordinator session:
-
-```
-EnterWorktree(name: "<work-name>")
-```
-
-After `EnterWorktree` returns, install eval's per-worktree dependencies:
-
-```bash
-ln -s /workspaces/eval/frontend/node_modules ./frontend/node_modules
-```
-
-The coordinator works from its worktree for the rest of the session. Reviewers and the test-runner enter this same worktree.
-
-### 2. Implement Tasks
+### 1. Implement Tasks
 
 **Follow the dependency graph from beads.** Spawn all currently-unblocked tasks in parallel. When a task completes, check if any blocked tasks are now unblocked and spawn those.
 
@@ -77,67 +61,48 @@ For each task:
 bd update <task-id> --set-labels wip --json
 ```
 
-#### b. Create Per-Task Worktree
+#### b. Spawn Implementer Subagent
 
-Per-task worktrees are created manually so the eval-specific node_modules symlink is in place before the implementer subagent starts:
-
-```bash
-git branch feature/<work-name>/<task-id> feature/<work-name>
-git worktree add ../<project>-<task-id> feature/<work-name>/<task-id>
-ln -s /workspaces/eval/frontend/node_modules ../<project>-<task-id>/frontend/node_modules
-```
-
-#### c. Spawn Implementer Subagent
-
-Use the Task tool with `subagent_type: "general-purpose"` and `model: "sonnet"`:
+Use the Agent tool with `isolation: "worktree"` and `model: "sonnet"`:
 
 ```
 ROLE: Implementer
 SKILL: Read and follow .claude/skills/implementer/SKILL.md
 
-WORKTREE: ../<project>-<task-id>
 TASK: <task-id>
 Read the task description: bd show <task-id> --json
-
-CONSTRAINTS:
-- Work ONLY in the worktree path above
-- Do NOT modify beads issues
-- Commit and push your work when implementer phases are complete
-- Phase 5 of the implementer skill produces a structured summary — that is your final output
 ```
 
-#### d. Handle Result
+#### c. Handle Result
 
-The implementer's final output is a structured summary (Phase 5). Only read that summary — ignore intermediate tool output from the subagent.
+The implementer's final output is a structured summary (Phase 5). Only read that summary — ignore intermediate tool output from the subagent. The Agent tool's result metadata exposes `worktree_path` and `branch` for integration.
 
 **On SUCCESS:** integrate into the feature branch (sequential — do NOT run in parallel with other integrations).
 
-**Try fast-path rebase first** (inline bash — no subagent):
+**Try fast-path rebase first** (inline — no subagent):
 
 ```bash
-cd ../<project>-<task-id>
-git rebase <target-branch> && \
-  git branch -f <target-branch> HEAD && \
-  git worktree remove ../<project>-<task-id> --force 2>/dev/null; \
-  git branch -D <source-branch> 2>/dev/null; \
+cd <worktree_path>
+git rebase feature/<work-name> && \
+  git branch -f feature/<work-name> HEAD && \
+  git worktree remove <worktree_path> --force 2>/dev/null && \
+  git branch -D <branch> 2>/dev/null && \
   echo "REBASE: OK"
 ```
 
-If the rebase command fails (conflict), abort and fall back to a rebase subagent:
+If the rebase command fails (conflict), abort and fall back to a rebase subagent (no `isolation: "worktree"` — it enters the implementer's existing worktree):
 
 ```bash
 git rebase --abort
 ```
 
-Then spawn the rebase subagent to resolve conflicts:
-
 ```
 ROLE: Rebase Agent (Conflict Resolution)
 SKILL: Read and follow .claude/skills/rebase/SKILL.md
 
-SOURCE: <source-branch>
-TARGET: <target-branch>
-WORKTREE: ../<project>-<task-id>
+SOURCE: <branch>
+TARGET: feature/<work-name>
+WORKTREE: <worktree_path>
 CLEANUP: true
 BEADS_IDS: <comma-separated task IDs whose changes are on the source branch>
 ```
@@ -156,7 +121,7 @@ Triage the "Concerns" section:
 - If blocked: note the blocker, move to next task
 - Do NOT close the task
 
-### 3. Pre-PR Review
+### 2. Pre-PR Review
 
 Reviews are **optional** for small, isolated changes (single-file fixes, typo corrections, config tweaks). For anything of any complexity — multi-file changes, new features, behavioral changes, refactors — reviews are **required**.
 
@@ -214,7 +179,7 @@ If the epic has e2e acceptance tests, run them here targeting the specific test 
 
 **Skip the test-runner entirely** if no integration tests or acceptance tests are needed (e.g., frontend-only changes with no store layer involvement and no e2e acceptance tests). **Do NOT create PR if the test-runner reports FAIL.** Fix locally first (spawn implementer if non-trivial).
 
-### 4. Create PR, Monitor CI, and Hand Off
+### 3. Create PR, Monitor CI, and Hand Off
 
 ```bash
 git push -u origin feature/<work-name>
@@ -301,6 +266,7 @@ export GH_TOKEN=$(cat /workspaces/eval/.gh-app-token)
 - Spawning a rebase subagent when there are no conflicts (use inline fast-path first)
 - Fixing non-trivial review issues inline — file issues and spawn implementers instead
 - Running quality gates directly in coordinator context — always delegate to test-runner sub-agents
+- Manually creating worktrees with `git worktree add` for subagents — use `isolation: "worktree"` so the `WorktreeCreate` hook handles setup
 - Using `isolation: "worktree"` for rebase/reviewer/test-runner agents — they enter the coordinator's existing worktree
 
 ## Hooks — What's Automatic vs Manual

--- a/.claude/skills/implementer/SKILL.md
+++ b/.claude/skills/implementer/SKILL.md
@@ -18,6 +18,7 @@ This skill covers development only — no issue tracking, no commits, no pushes.
 - **Test cases from the issue are your spec.** The planner defines concrete test cases on each task. Implement those first, then add high-value coverage for gaps. Focus on tests that catch real bugs — avoid exhaustive, duplicative unit tests that test constructors, wiring, or things the compiler already guarantees.
 - **Delegate quality gates to test-runner sub-agents.** Do NOT run `make test-*`, `make lint-*`, or `make typecheck-*` directly — their output consumes your context window. Use the Task tool to spawn a test-runner (see Phase 3). Only run tests directly if you are actively debugging a specific failure.
 - **Lint and typecheck are enforced by lefthook git hooks at commit time.** Do not run lint or typecheck commands manually — focus on tests in Phase 3.
+- **If a hook blocks a tool call, stop.** Never work around it with scripts, `sed`, or other indirect tricks. Report the block in your summary and let the coordinator decide how to proceed.
 
 ## Phase 1: Write Failing Tests
 

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -112,7 +112,13 @@ git rebase --abort
 ```
 Then output `RESULT: FAIL`.
 
-### 4. Advance target ref
+### 4. Run quality gates
+
+After a successful rebase, verify the result still passes. Pull the gate command from the **Quality Gates** table in CLAUDE.md (the same gate the implementer ran in Phase 3 — typically `make test-*` for the affected service, or pre-push equivalent).
+
+If it fails, the conflict resolution introduced an error. Fix it, amend the relevant commit, and re-run. If the fix is non-trivial, abort and escalate (`RESULT: FAIL`).
+
+### 5. Advance target ref
 
 ```bash
 git branch -f <target> HEAD
@@ -123,7 +129,7 @@ If `<target>` tracks a remote, also push:
 git push origin <target>
 ```
 
-### 5. Cleanup (if enabled)
+### 6. Cleanup (if enabled)
 
 ```bash
 git worktree remove <worktree> --force 2>/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ secrets.tfvars
 # Lefthook local overrides
 lefthook-local.yml
 
+# Stale-worktree marker (per-worktree, written by mark-stale-worktree.sh)
+.stale-worktree
+
 # Misc
 *.bak
 *.tmp


### PR DESCRIPTION
## Summary

- Adds a deterministic stale-worktree block: `mark-stale-worktree.sh` (SessionStart) drops a marker when pwd is inside a worktree; `block-stale-worktree.sh` (PreToolUse matcher `*`) refuses every tool except `EnterWorktree`/`ExitWorktree` until the agent clears it. Replaces the text-only "CRITICAL FIRST INSTRUCTION" warning that coordinators frequently ignored when resuming work in a stale worktree.
- Adds `worktree-create.sh` (WorktreeCreate) so subagents spawning with `isolation: "worktree"` get the right per-task setup (branch from caller HEAD, `frontend/node_modules` symlink) without manual `git worktree add` blocks in the coordinator.
- Adds `ask-on-main-edit.sh` (PreToolUse: Edit|Write|NotebookEdit) to require user approval when a write targets the main checkout. Catches the "I'm in a worktree but used an absolute main-repo path" mistake.
- Adds `set-repo-root.sh` (SessionStart + CwdChanged) so other hooks resolve via `$REPO_ROOT/.claude/hooks/...` from any worktree.

## Why this matters

The recurring failure mode has been coordinators resuming in a stale worktree from a previous session, getting distracted by the user's request, and starting work on whatever branch they were left on — stale reads, wrong-branch edits, lost work. Strong warning text wasn't enough; deterministic enforcement is. The block message includes a fallback for the rare concurrent-legit case: "if this is NOT a fresh session and another agent is legitimately working in this worktree, pause and check in with the user before proceeding."

## Skill cleanups

- `commands/work.md`: drops the duplicated `## 1. Parse Input` (the `bd-*` / `#<N>` rules didn't match real beads ID formats). Input parsing now lives only in the coordinator skill, with a "try `bd show` first" fuzzy disambiguation.
- `coordinator/SKILL.md`: drops the manual Setup section and per-task worktree creation block — `/work` owns the coordinator's worktree, the WorktreeCreate hook owns subagent worktrees. Integration uses `worktree_path` / `branch` from the implementer Agent result.
- `implementer/SKILL.md`: adds "if a hook blocks a tool call, stop — never work around it" principle.
- `rebase/SKILL.md`: adds Phase 4 "Run quality gates" after conflict resolution, before advancing the target ref.

## Test plan

- [ ] Start a fresh session inside `.claude/worktrees/<existing>` — verify the first tool call gets blocked with the new message.
- [ ] From the block, call `ExitWorktree(action: "keep")` — verify subsequent tools pass through.
- [ ] From the main checkout, run `/work some-task` — verify the worktree is created and entered, no block fires.
- [ ] Spawn an implementer subagent with `isolation: "worktree"` — verify `worktree-create.sh` creates the worktree with the `frontend/node_modules` symlink.
- [ ] Attempt to Edit a file at an absolute path inside the main checkout from a worktree — verify the ask-on-main-edit prompt fires.