### PR TITLE
chore(skills): port planner/implementer/reviewer/coordinator improvements

### DIFF
--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -75,7 +75,7 @@ Read the task description: bd show <task-id> --json
 
 #### c. Handle Result
 
-The implementer's final output is a structured summary (Phase 5). Only read that summary — ignore intermediate tool output from the subagent. The Agent tool's result metadata exposes `worktree_path` and `branch` for integration.
+The implementer's final output is a structured summary (Phase 4). Only read that summary — ignore intermediate tool output from the subagent. The Agent tool's result metadata exposes `worktree_path` and `branch` for integration.
 
 **On implementer FAILURE or STALL** (timeout, crash, incomplete summary): don't silently drop the work. Choose one — retry with continuation, finish the task inline, or ask the user how to proceed.
 
@@ -146,7 +146,8 @@ SKILL: Read and follow .claude/skills/reviewer-correctness/SKILL.md
 
 WORKTREE: <coordinator's worktree path>
 BASE: origin/main
-SUMMARY: <what this PR implements>
+DIFF RANGE: origin/main...HEAD
+BEADS: <bd-id(s)>
 ```
 
 **Test Quality Reviewer:**
@@ -156,7 +157,8 @@ SKILL: Read and follow .claude/skills/reviewer-tests/SKILL.md
 
 WORKTREE: <coordinator's worktree path>
 BASE: origin/main
-SUMMARY: <what this PR implements>
+DIFF RANGE: origin/main...HEAD
+BEADS: <bd-id(s)>
 ```
 
 **Architecture Reviewer:**
@@ -166,9 +168,12 @@ SKILL: Read and follow .claude/skills/reviewer-architecture/SKILL.md
 
 WORKTREE: <coordinator's worktree path>
 BASE: origin/main
-SUMMARY: <what this PR implements>
-REFERENCE DIRS: <key directories in the existing codebase to compare against>
+DIFF RANGE: origin/main...HEAD
+BEADS: <bd-id(s)>
+REFERENCE DIRS: <existing dirs to compare against — paths only, not "areas of concern">
 ```
+
+**Pass mechanical context only — route, don't narrate.** The reviewer reads the diff (`DIFF RANGE`) and the task intent (`bd show <BEADS>`, written pre-review so neutral) itself. Do **not** hand-author a summary of "what this PR implements" — composed right after your own analysis, it seeds the reviewers with your priors. If an orientation line is truly needed, pull it from a pre-existing neutral source (bd description, PR title), never your working memory.
 
 **Handle review results:**
 

--- a/.claude/skills/implementer/SKILL.md
+++ b/.claude/skills/implementer/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: implementer
-description: Pure development workflow with test-first development and coverage review. Used by coordinator as a subagent. Never manages beads issues or commits.
+description: Pure development workflow with required test coverage and a coverage audit. Used by coordinator as a subagent. Commits work but never manages beads issues.
 ---
 
 # Implementer
 
-Follow these phases **in strict order**. Do not skip phases. Do not proceed until the current phase's gate is satisfied.
+Work through these phases in order. Don't skip a phase's gate.
 
-This skill covers development only — no issue tracking, no commits, no pushes. The coordinator handles those.
+This skill covers development and commits your work — no issue tracking, no pushes. The coordinator handles those.
 
 ## Principles
 
@@ -17,31 +17,25 @@ This skill covers development only — no issue tracking, no commits, no pushes.
 - No type casts that bypass the type system.
 - No optional chaining on required properties.
 - **Test cases from the issue are your spec.** The planner defines concrete test cases on each task. Implement those first, then add high-value coverage for gaps. Focus on tests that catch real bugs — avoid exhaustive, duplicative unit tests that test constructors, wiring, or things the compiler already guarantees.
-- **Delegate quality gates to test-runner sub-agents.** Do NOT run `make test-*`, `make lint-*`, or `make typecheck-*` directly — their output consumes your context window. Use the Task tool to spawn a test-runner (see Phase 3). Only run tests directly if you are actively debugging a specific failure.
-- **Lint and typecheck are enforced by lefthook git hooks at commit time.** Do not run lint or typecheck commands manually — focus on tests in Phase 3.
+- **Delegate quality gates to test-runner sub-agents.** Do NOT run `make test-*`, `make lint-*`, or `make typecheck-*` directly — their output consumes your context window. Use the Task tool to spawn a test-runner (see Phase 2). Only run tests directly if you are actively debugging a specific failure.
+- **Lint and typecheck are enforced by lefthook git hooks at commit time.** Do not run lint or typecheck commands manually — focus on tests in Phase 2.
 - **If a hook blocks a tool call, stop.** Never work around it with scripts, `sed`, or other indirect tricks. Report the block in your summary and let the coordinator decide how to proceed.
 
-## Phase 1: Write Failing Tests
+## Phase 1: Implement & Test
 
-Implement the **test cases defined in the task issue** before touching production code. These are your acceptance criteria — they define what "done" looks like.
+Make the production change and add the test coverage the task specifies — in whatever order is most efficient (write tests first if it helps you design, or implement first and cover after). Keep changes minimal and focused on the task.
 
-1. Read the task description (`bd show <task-id> --json`) and identify the test cases
-2. Read the relevant production code to understand current behavior
-3. Implement each specified test case
-4. Add additional high-value tests for gaps you identify (error paths, edge cases) — but focus on quality over quantity. A few well-targeted tests beat many shallow ones.
-5. Verify your new tests fail by delegating to a test-runner sub-agent (see Phase 3)
+1. Read the task description (`bd show <task-id> --json`) and identify the required test cases.
+2. Read the relevant production code to understand current behavior.
+3. Make the change and implement each specified test case. Add targeted tests for gaps you identify (error paths, edge cases) — quality over quantity; a few well-aimed tests beat many shallow ones.
 
 **Test documentation:** Planned and critical tests (integration, e2e, non-obvious unit tests) must include a docstring answering: what contract is verified, why it matters, what breaks if violated. Go table-driven tests with descriptive names are often self-documenting — use judgment.
 
 **Skipping tests:** Only for genuinely test-free changes (pure config, copy, env vars). Migrations, refactors, and wiring still need tests.
 
-**Gate:** Your new tests **fail** (or, for pure deletions/removals, you can write tests asserting the old behavior is gone — these will pass after implementation). If your new tests already pass, they are not testing anything new. Rewrite them.
+**Gate:** Every test case the task specifies is implemented, and your new tests meaningfully exercise the change — a test that would pass even without your production change isn't testing it.
 
-## Phase 2: Implement
-
-Make the production code changes. Keep changes minimal and focused on the task.
-
-## Phase 3: Verify
+## Phase 2: Verify
 
 **Delegate quality gate runs to a test-runner sub-agent** to preserve your context window. Do NOT run these commands directly with the Bash tool — test output is verbose and wastes context you need for later phases. Use the Task tool with `subagent_type: "Bash"` and `model: "haiku"`:
 
@@ -58,13 +52,15 @@ COMMANDS:
 
 **Gate:** Sub-agent reports PASS. If FAIL, read the error summary, fix the issue, and re-delegate. Only run quality gates directly in your own context if you need to debug a failure interactively.
 
-## Phase 4: Test Coverage Audit
+After Phase 2 (Verify) passes, stage and commit all your changes on the current branch.
+
+## Phase 3: Test Coverage Audit
 
 Verify all planned test cases are implemented. Then check for meaningful gaps: changed behavior with no test that would catch a regression. Focus on real failure modes, not exhaustive coverage. If gaps exist, write targeted tests and re-run via test-runner.
 
 **Gate:** All planned test cases implemented. No meaningful coverage gaps, or gaps documented with reasoning.
 
-## Phase 5: Summary
+## Phase 4: Summary
 
 **This must be the very last thing you output.** The coordinator reads your result — keep it concise to avoid polluting its context.
 

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -21,7 +21,7 @@ You are a planner agent. Your job is to collaboratively design implementation pl
 
 Before proposing anything, understand the landscape:
 
-1. Read the epic/description to understand the goal
+1. Read the epic/description to understand the goal — including the **user-facing goal**: who the change is for (an end-user, another developer, whoever consumes it) and the observable outcome they need. **If this isn't clear, interrogate the user before going further** — it's critical context that shapes scope, tradeoffs, and the plan itself; don't infer it silently.
 2. Explore the codebase:
    - Existing patterns and conventions
    - Shared types and packages
@@ -100,7 +100,7 @@ A future implementer session must understand the task completely from its descri
 
 Each subtask includes a **Test Cases** section with concrete, named scenarios specifying type (integration/e2e/unit), setup, assertions, and what bug it catches. Be prescriptive — pseudo-code or detailed steps, not vague one-liners. The user reviews and approves test cases as part of plan approval.
 
-**Prefer integration tests** — they exercise real dependencies and catch real bugs. Only specify e2e when frontend behavior is being validated. Unit tests are rarely appropriate as acceptance tests; they're better suited for additional coverage the implementer adds.
+**Prefer integration tests** — they exercise real dependencies and catch real bugs. Only specify e2e when frontend behavior is being validated. Unit tests are rarely appropriate as acceptance tests; they're better suited for additional coverage the implementer adds — but not tests that merely assert deleted code is gone.
 
 **Examples:**
 

--- a/.claude/skills/reviewer-architecture/SKILL.md
+++ b/.claude/skills/reviewer-architecture/SKILL.md
@@ -19,8 +19,10 @@ You review the full codebase — not just the diff — to catch duplication, pat
 
 - Worktree path
 - Base branch (e.g., `origin/main`)
-- Summary of what the PR implements
+- Beads issue ID(s) for the work — run `bd show <id>` to read the task intent yourself
 - Reference directories to compare against (if provided)
+
+**You own the question-space.** The diff and the surrounding codebase are your source of truth: read them and reach your own conclusions about duplication, divergence, and structure, then run a full independent pass. Reference dirs (if provided) are a starting point for comparison, not its bounds. The structural problems that matter most are the ones nobody flagged.
 
 ## Review Process
 

--- a/.claude/skills/reviewer-correctness/SKILL.md
+++ b/.claude/skills/reviewer-correctness/SKILL.md
@@ -19,7 +19,9 @@ You review the full branch diff for correctness issues. You read every changed l
 
 - Worktree path
 - Base branch (e.g., `origin/main`)
-- Summary of what the PR implements
+- Beads issue ID(s) for the work — run `bd show <id>` to read the task intent yourself
+
+**You own the question-space.** The diff is your source of truth: read every changed line, decide for yourself what could be wrong, and run a full independent pass. The bugs that matter most are the ones nobody flagged.
 
 ## Review Process
 

--- a/.claude/skills/reviewer-tests/SKILL.md
+++ b/.claude/skills/reviewer-tests/SKILL.md
@@ -19,7 +19,9 @@ You evaluate whether the tests in a PR are meaningful. High coverage with bad te
 
 - Worktree path
 - Base branch (e.g., `origin/main`)
-- Summary of what the PR implements
+- Beads issue ID(s) for the work — run `bd show <id>` to read the task intent and planned test cases yourself
+
+**You own the question-space.** The diff and the task's planned test cases are your source of truth: enumerate the new and changed behaviors yourself, ask of each whether a regression would fail a test, and run a full independent pass. The coverage gaps that matter most are the ones nobody flagged.
 
 ## Review Process
 
@@ -63,7 +65,7 @@ Then check:
 - Do tests verify actual behavior, or just that code doesn't crash? Would a regression be caught?
 - Are assertions checking the right things? (e.g., response body, not just status code)
 - Could a completely wrong implementation still pass? (sign of over-mocking or weak assertions)
-- Flag low-value tests: tautologies (`ctx != nil`), `err == nil` without checking the result, no assertions, exhaustive unit tests for constructors/getters/wiring
+- Flag low-value tests: tautologies (`ctx != nil`), `err == nil` without checking the result, no assertions, exhaustive unit tests for constructors/getters/wiring, tests that merely assert deleted code is gone (the build and the diff already verify removal)
 
 #### Integration Test Coverage
 - Are database interactions tested against a real database (Docker Postgres with migrations)?


### PR DESCRIPTION
## What

Ports generic workflow-skill improvements from the upstream agent-workflow/AJC line, adapted to eval's Go/Next.js stack and `origin/main` base convention.

- **planner** — pin the user-facing goal; interrogate the user if it's unclear
- **implementer** — drop the test-first ceremony (5 phases → 4), keep required coverage
- **reviewer-tests / planner** — don't write tests that just assert deleted code is gone
- **reviewers** — add "you own the question-space" independence framing
- **coordinator** — route, don't narrate: pass mechanical context only; drop the hand-authored `SUMMARY` field that anchors reviewers with the coordinator's priors (also fixes the stale implementer-summary phase reference)

## Notes
Generic engineering-practice wording only — no proprietary content from the private source repo. eval's existing `origin/main` base convention and Go/Jest test framing preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
